### PR TITLE
Added back pressure to WriteStream

### DIFF
--- a/src/main/java/io/gravitee/gateway/api/stream/WriteStream.java
+++ b/src/main/java/io/gravitee/gateway/api/stream/WriteStream.java
@@ -15,6 +15,8 @@
  */
 package io.gravitee.gateway.api.stream;
 
+import io.gravitee.gateway.api.handler.Handler;
+
 /**
  * Stream writer.
  *
@@ -34,4 +36,8 @@ public interface WriteStream<T> {
         write(t);
         end();
     }
+
+    default WriteStream<T> drainHandler(Handler<Void> drainHandler) { return this; }
+
+    default boolean writeQueueFull() { return false; }
 }


### PR DESCRIPTION
To support back-pressure, write stream must be queryable about their queue size. Also, we need to register a handler to know when they are able to receive buffers again, the drain handler.