### PR TITLE
fix(http): Since vertx 3.6.x it can happen that requests without body…

### DIFF
--- a/src/main/java/io/gravitee/gateway/api/Request.java
+++ b/src/main/java/io/gravitee/gateway/api/Request.java
@@ -128,4 +128,6 @@ public interface Request extends ReadStream<Buffer> {
     SSLSession sslSession();
 
     Metrics metrics();
+
+    boolean ended();
 }

--- a/src/main/java/io/gravitee/gateway/api/RequestWrapper.java
+++ b/src/main/java/io/gravitee/gateway/api/RequestWrapper.java
@@ -142,4 +142,9 @@ public abstract class RequestWrapper implements Request {
     public SSLSession sslSession() {
         return request.sslSession();
     }
+
+    @Override
+    public boolean ended() {
+        return request.ended();
+    }
 }


### PR DESCRIPTION
… (e.g. a GET) are ended even while in paused-state

Closes gravitee-io/issues#2020