### PR TITLE
fix(http): Keep the status message as part of the response for consumer

### DIFF
--- a/src/main/java/io/gravitee/gateway/api/Response.java
+++ b/src/main/java/io/gravitee/gateway/api/Response.java
@@ -32,6 +32,14 @@ public interface Response extends WriteStream<Buffer> {
     int status();
 
     /**
+     * Reason-Phrase is intended to give a short textual description of the Status-Code.
+     * @return
+     */
+    String reason();
+
+    Response reason(String message);
+
+    /**
      * @return the headers in the response.
      */
     HttpHeaders headers();

--- a/src/main/java/io/gravitee/gateway/api/proxy/ProxyResponse.java
+++ b/src/main/java/io/gravitee/gateway/api/proxy/ProxyResponse.java
@@ -31,6 +31,12 @@ public interface ProxyResponse extends ReadStream<Buffer> {
     int status();
 
     /**
+     * Reason-Phrase is intended to give a short textual description of the Status-Code.
+     * @return
+     */
+    default String reason() { return null; }
+
+    /**
      * @return the headers in the response.
      */
     HttpHeaders headers();


### PR DESCRIPTION
Closes gravitee-io/issues#2381