### PR TITLE
feat(processor): add path parameters processing

### DIFF
--- a/src/main/java/io/gravitee/gateway/api/Request.java
+++ b/src/main/java/io/gravitee/gateway/api/Request.java
@@ -80,6 +80,11 @@ public interface Request extends ReadStream<Buffer> {
     MultiValueMap<String, String> parameters();
 
     /**
+     * @return the path parameters in the request
+     */
+    MultiValueMap<String, String> pathParameters();
+
+    /**
      * @return the headers in the request.
      */
     HttpHeaders headers();

--- a/src/main/java/io/gravitee/gateway/api/RequestWrapper.java
+++ b/src/main/java/io/gravitee/gateway/api/RequestWrapper.java
@@ -96,6 +96,11 @@ public abstract class RequestWrapper implements Request {
     }
 
     @Override
+    public MultiValueMap<String, String> pathParameters() {
+        return request.pathParameters();
+    }
+
+    @Override
     public HttpHeaders headers() {
         return request.headers();
     }

--- a/src/main/java/io/gravitee/gateway/api/el/EvaluableRequest.java
+++ b/src/main/java/io/gravitee/gateway/api/el/EvaluableRequest.java
@@ -1,0 +1,111 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gateway.api.el;
+
+import io.gravitee.common.http.HttpHeaders;
+import io.gravitee.common.util.MultiValueMap;
+import io.gravitee.gateway.api.Request;
+
+/**
+ * @author David BRASSELY (david.brassely at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+public class EvaluableRequest {
+
+    private final Request request;
+    private final String content;
+
+    public EvaluableRequest(final Request request) {
+        this(request, null);
+    }
+
+    public EvaluableRequest(final Request request, final String content) {
+        this.request = request;
+        this.content = content;
+    }
+
+    public String getId() {
+        return request.id();
+    }
+
+    public String getTransactionId() {
+        return request.transactionId();
+    }
+
+    public String getUri() {
+        return request.uri();
+    }
+
+    public String getPath() {
+        return request.path();
+    }
+
+    public String[] getPaths() {
+        return request.path().split("/");
+    }
+
+    public String getPathInfo() {
+        return request.pathInfo();
+    }
+
+    public String[] getPathInfos() {
+        return request.pathInfo().split("/");
+    }
+
+    public String getContextPath() {
+        return request.contextPath();
+    }
+
+    public MultiValueMap<String, String> getParams() {
+        return request.parameters();
+    }
+
+    public MultiValueMap<String, String> getPathParams() {
+        return request.pathParameters();
+    }
+
+    public HttpHeaders getHeaders() {
+        return request.headers();
+    }
+
+    public String getMethod() {
+        return request.rawMethod();
+    }
+
+    public String getScheme() {
+        return request.scheme();
+    }
+
+    public String getVersion() {
+        return request.version().name();
+    }
+
+    public long getTimestamp() {
+        return request.timestamp();
+    }
+
+    public String getRemoteAddress() {
+        return request.localAddress();
+    }
+
+    public String getLocalAddress() {
+        return request.localAddress();
+    }
+
+    public String getContent() {
+        return content;
+    }
+}

--- a/src/main/java/io/gravitee/gateway/api/el/EvaluableResponse.java
+++ b/src/main/java/io/gravitee/gateway/api/el/EvaluableResponse.java
@@ -1,0 +1,50 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gateway.api.el;
+
+import io.gravitee.common.http.HttpHeaders;
+import io.gravitee.gateway.api.Response;
+
+/**
+ * @author David BRASSELY (david.brassely at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+public class EvaluableResponse {
+
+    private final Response response;
+    private final String content;
+
+    public EvaluableResponse(final Response response) {
+        this(response, null);
+    }
+
+    public EvaluableResponse(final Response response, final String content) {
+        this.response = response;
+        this.content = content;
+    }
+
+    public int getStatus() {
+        return response.status();
+    }
+
+    public HttpHeaders getHeaders() {
+        return response.headers();
+    }
+
+    public String getContent() {
+        return content;
+    }
+}


### PR DESCRIPTION
* Add Path Parameters in execution context, so they can be used in EL engine
* Move `EvaluableRequest` and `EvaluableResponse` to gateway-api repo, to be shared with policies

Closes gravitee-io/issues#4431