### PR TITLE
feat: add deeplyEquals method for HttpHeaders

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.gravitee</groupId>
         <artifactId>gravitee-parent</artifactId>
-        <version>20.0</version>
+        <version>20.1</version>
     </parent>
 
     <groupId>io.gravitee.gateway</groupId>
@@ -34,7 +34,7 @@
     <name>Gravitee.io APIM - Gateway - API</name>
 
     <properties>
-        <gravitee-bom.version>1.0</gravitee-bom.version>
+        <gravitee-bom.version>2.0</gravitee-bom.version>
         <gravitee-tracing-api.version>1.0.0</gravitee-tracing-api.version>
         <gravitee-common.version>1.24.0</gravitee-common.version>
         <gravitee-policy-api.version>1.11.0</gravitee-policy-api.version>
@@ -94,13 +94,23 @@
 
         <!-- Unit Tests -->
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-params</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/src/main/java/io/gravitee/gateway/api/http/HttpHeaders.java
+++ b/src/main/java/io/gravitee/gateway/api/http/HttpHeaders.java
@@ -91,4 +91,24 @@ public interface HttpHeaders extends Iterable<Map.Entry<String, String>> {
     default boolean containsAllKeys(Collection<String> names) {
         return names().containsAll(names.stream().map(String::toLowerCase).collect(Collectors.toList()));
     }
+
+    /**
+     * Indicates if this instance of HttpHeaders is deeply equal to another one.
+     * Comparison is made on size equality, key-set equality, then on equality of collection of values for each key.
+     * @param other the other HttpHeaders instance to compare with this one
+     * @return true if instance are deeply equal, else returns false
+     */
+    default boolean deeplyEquals(HttpHeaders other) {
+        if (this.size() != other.size() || !this.names().containsAll(other.names())) {
+            return false;
+        }
+
+        for (String name : this.names()) {
+            final List<String> otherValues = other.getAll(name);
+            if (!otherValues.equals(this.getAll(name))) {
+                return false;
+            }
+        }
+        return true;
+    }
 }

--- a/src/test/java/io/gravitee/gateway/api/el/EvaluableExtractorTest.java
+++ b/src/test/java/io/gravitee/gateway/api/el/EvaluableExtractorTest.java
@@ -16,13 +16,7 @@
 package io.gravitee.gateway.api.el;
 
 import java.io.IOException;
-import javax.net.ssl.SSLPeerUnverifiedException;
-import javax.net.ssl.SSLSession;
-import javax.security.auth.x500.X500Principal;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
-import org.mockito.Mockito;
+import org.junit.jupiter.api.Test;
 
 public class EvaluableExtractorTest {
 

--- a/src/test/java/io/gravitee/gateway/api/el/EvaluableSSLSessionTest.java
+++ b/src/test/java/io/gravitee/gateway/api/el/EvaluableSSLSessionTest.java
@@ -15,7 +15,9 @@
  */
 package io.gravitee.gateway.api.el;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -24,8 +26,8 @@ import java.util.List;
 import javax.net.ssl.SSLPeerUnverifiedException;
 import javax.net.ssl.SSLSession;
 import javax.security.auth.x500.X500Principal;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class EvaluableSSLSessionTest {
 
@@ -41,7 +43,7 @@ public class EvaluableSSLSessionTest {
     private X500Principal clientPrincipal;
     private X500Principal serverPrincipal;
 
-    @Before
+    @BeforeEach
     public void init() throws SSLPeerUnverifiedException {
         sslSession = mock(SSLSession.class);
         clientPrincipal = mock(X500Principal.class);

--- a/src/test/java/io/gravitee/gateway/api/http/HttpHeadersTest.java
+++ b/src/test/java/io/gravitee/gateway/api/http/HttpHeadersTest.java
@@ -1,0 +1,84 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gateway.api.http;
+
+import java.util.List;
+import java.util.stream.Stream;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+/**
+ * @author Yann TAVERNIER (yann.tavernier at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+public class HttpHeadersTest {
+
+    @ParameterizedTest(name = "#{index} - {3}")
+    @MethodSource("provideHttpHeadersDataForDeeplyEqualsTest")
+    public void shouldTestDeeplyEquality(HttpHeaders headers1, HttpHeaders headers2, boolean expectedResult, String testName) {
+        Assertions.assertThat(headers1.deeplyEquals(headers2)).isEqualTo(expectedResult);
+        Assertions.assertThat(headers2.deeplyEquals(headers1)).isEqualTo(expectedResult);
+    }
+
+    /**
+     * Provide a stream of Arguments for testing deeplyEquals function.
+     *
+     * @return a Stream of Arguments composed of
+     * - A HttpHeaders object
+     * - A second HttpHeaders to compare with the first one
+     * - The expected equality result
+     * - The display name of the test case
+     */
+    private static Stream<Arguments> provideHttpHeadersDataForDeeplyEqualsTest() {
+        return Stream.of(
+            Arguments.of(
+                HttpHeaders.create().add("Host", "test.gravitee.io").add("Accept", List.of("application/json", "application/json+vnd")),
+                HttpHeaders.create().add("Host", "test.gravitee.io").add("Accept", List.of("application/json", "application/json+vnd")),
+                true,
+                "HttpHeaders are equals"
+            ),
+            Arguments.of(
+                HttpHeaders.create().add("Host", "test.gravitee.io").add("Accept", List.of("application/json", "application/json+vnd")),
+                HttpHeaders.create().add("Host", "test.gravitee.io").add("Accept", "application/json"),
+                false,
+                "HttpHeaders are not equals: not same size in values"
+            ),
+            Arguments.of(
+                HttpHeaders.create().add("Host", "test.gravitee.io").add("Accept", List.of("application/json", "application/json+vnd")),
+                HttpHeaders.create().add("Host", "test.gravitee.io").add("Accept", List.of("application/json", "application/xml")),
+                false,
+                "HttpHeaders are not equals: different values"
+            ),
+            Arguments.of(
+                HttpHeaders.create().add("Host", "test.gravitee.io").add("Accept", List.of("application/json", "application/json+vnd")),
+                HttpHeaders.create().add("Host", "test.gravitee.io"),
+                false,
+                "HttpHeaders are not equals: key-sets have different sizes"
+            ),
+            Arguments.of(
+                HttpHeaders.create().add("Host", "test.gravitee.io").add("Accept", List.of("application/json", "application/json+vnd")),
+                HttpHeaders
+                    .create()
+                    .add("Host", "test.gravitee.io")
+                    .add("X-Not-Expected-Header", List.of("application/json", "application/json+vnd")),
+                false,
+                "HttpHeaders are not equals: first key-set does not contains all key of second"
+            )
+        );
+    }
+}


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/issues/issues/6946

**Description**

Add `deeplyEquals` method on HttpHeaders to be able to have deep equality on this object.