### PR TITLE
fix: add a close handler on the request interface

### DIFF
--- a/src/main/java/io/gravitee/gateway/api/Request.java
+++ b/src/main/java/io/gravitee/gateway/api/Request.java
@@ -156,4 +156,11 @@ public interface Request extends ReadStream<Buffer> {
      * @return
      */
     Request customFrameHandler(Handler<HttpFrame> frameHandler);
+
+    /**
+     *
+     * @param closeHandler The handler to call when the underlying connection is closed
+     * @return the request
+     */
+    Request closeHandler(Handler<Void> closeHandler);
 }

--- a/src/main/java/io/gravitee/gateway/api/RequestWrapper.java
+++ b/src/main/java/io/gravitee/gateway/api/RequestWrapper.java
@@ -173,4 +173,9 @@ public abstract class RequestWrapper implements Request {
     public Request customFrameHandler(Handler<HttpFrame> frameHandler) {
         return request.customFrameHandler(frameHandler);
     }
+
+    @Override
+    public Request closeHandler(Handler<Void> closeHandler) {
+        return request.closeHandler(closeHandler);
+    }
 }

--- a/src/main/java/io/gravitee/gateway/api/proxy/ProxyRequest.java
+++ b/src/main/java/io/gravitee/gateway/api/proxy/ProxyRequest.java
@@ -18,6 +18,7 @@ package io.gravitee.gateway.api.proxy;
 import io.gravitee.common.http.HttpHeaders;
 import io.gravitee.common.http.HttpMethod;
 import io.gravitee.common.util.MultiValueMap;
+import io.gravitee.gateway.api.handler.Handler;
 import io.gravitee.reporter.api.http.Metrics;
 import java.net.URI;
 import java.util.Map;
@@ -57,4 +58,6 @@ public interface ProxyRequest {
      * @return the metrics attached to the request.
      */
     Metrics metrics();
+
+    ProxyRequest closeHandler(Handler<Void> closeHandler);
 }

--- a/src/main/java/io/gravitee/gateway/api/proxy/builder/ProxyRequestBuilder.java
+++ b/src/main/java/io/gravitee/gateway/api/proxy/builder/ProxyRequestBuilder.java
@@ -84,9 +84,9 @@ public class ProxyRequestBuilder {
         ProxyRequestImpl proxyRequest;
 
         if (!request.isWebSocket()) {
-            proxyRequest = new ProxyRequestImpl(this.request.metrics());
+            proxyRequest = new ProxyRequestImpl(this.request);
         } else {
-            proxyRequest = new WebSocketProxyRequestImpl(this.request.websocket(), this.request.metrics());
+            proxyRequest = new WebSocketProxyRequestImpl(this.request);
         }
 
         // Remove duplicate slash

--- a/src/main/java/io/gravitee/gateway/api/proxy/builder/ProxyRequestImpl.java
+++ b/src/main/java/io/gravitee/gateway/api/proxy/builder/ProxyRequestImpl.java
@@ -18,6 +18,8 @@ package io.gravitee.gateway.api.proxy.builder;
 import io.gravitee.common.http.HttpHeaders;
 import io.gravitee.common.http.HttpMethod;
 import io.gravitee.common.util.MultiValueMap;
+import io.gravitee.gateway.api.Request;
+import io.gravitee.gateway.api.handler.Handler;
 import io.gravitee.gateway.api.proxy.ProxyRequest;
 import io.gravitee.reporter.api.http.Metrics;
 
@@ -32,10 +34,10 @@ public class ProxyRequestImpl implements ProxyRequest {
     private HttpMethod method;
     private String rawMethod;
     private HttpHeaders headers;
-    private final Metrics metrics;
+    private final Request request;
 
-    protected ProxyRequestImpl(Metrics metrics) {
-        this.metrics = metrics;
+    protected ProxyRequestImpl(final Request request) {
+        this.request = request;
     }
 
     public void setUri(String uri) {
@@ -85,6 +87,12 @@ public class ProxyRequestImpl implements ProxyRequest {
 
     @Override
     public Metrics metrics() {
-        return metrics;
+        return request.metrics();
+    }
+
+    @Override
+    public ProxyRequest closeHandler(Handler<Void> closeHandler) {
+        request.closeHandler(closeHandler);
+        return this;
     }
 }

--- a/src/main/java/io/gravitee/gateway/api/proxy/ws/WebSocketProxyRequestImpl.java
+++ b/src/main/java/io/gravitee/gateway/api/proxy/ws/WebSocketProxyRequestImpl.java
@@ -15,21 +15,20 @@
  */
 package io.gravitee.gateway.api.proxy.ws;
 
+import io.gravitee.gateway.api.Request;
 import io.gravitee.gateway.api.handler.Handler;
 import io.gravitee.gateway.api.proxy.builder.ProxyRequestImpl;
 import io.gravitee.gateway.api.ws.WebSocket;
 import io.gravitee.gateway.api.ws.WebSocketFrame;
-import io.gravitee.reporter.api.http.Metrics;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.CompletionStage;
 
 public class WebSocketProxyRequestImpl extends ProxyRequestImpl implements WebSocketProxyRequest {
 
     private final WebSocket websocket;
 
-    public WebSocketProxyRequestImpl(final WebSocket websocket, final Metrics metrics) {
-        super(metrics);
-        this.websocket = websocket;
+    public WebSocketProxyRequestImpl(final Request request) {
+        super(request);
+        this.websocket = request.websocket();
     }
 
     @Override


### PR DESCRIPTION
This handler allows to react upon client closing a connection.

This is useful when e.g. a SSE client calls `EventSource.close` to propagate
this event to the upstream service

see https://github.com/gravitee-io/issues/issues/7093
see https://github.com/gravitee-io/gravitee-api-management/pull/1653
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `1.27.4-feat-request-close-handler-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/gateway/gravitee-gateway-api/1.27.4-feat-request-close-handler-SNAPSHOT/gravitee-gateway-api-1.27.4-feat-request-close-handler-SNAPSHOT.zip)
  <!-- Version placeholder end -->
