### PR TITLE
fix(jupiter): remove isInterrupted method from ctx

### DIFF
--- a/src/main/java/io/gravitee/gateway/reactive/api/context/ExecutionContext.java
+++ b/src/main/java/io/gravitee/gateway/reactive/api/context/ExecutionContext.java
@@ -63,15 +63,6 @@ public interface ExecutionContext {
      */
     Completable interruptWith(final ExecutionFailure failure);
 
-    /**
-     * Indicates if the execution has been interrupted.
-     * An execution interrupted does not indicate that the response is really ended and has been push to the downstream.
-     * Instead, it indicates that an actor of the request processing has indicated that the execution has been interrupted with or without {@link ExecutionFailure}  and other steps should potentially be discarded.
-     *
-     * @return a boolean indicated the response has been interrupted or not.
-     */
-    boolean isInterrupted();
-
     // TODO will need to be introduce in future
     // ExecutableApi executableApi();
 


### PR DESCRIPTION
**Description**

Remove interrupted field and method from context because unused anymore.
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `1.33.0-prototype-reactive-interuption-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/gateway/gravitee-gateway-api/1.33.0-prototype-reactive-interuption-SNAPSHOT/gravitee-gateway-api-1.33.0-prototype-reactive-interuption-SNAPSHOT.zip)
  <!-- Version placeholder end -->
