### PR TITLE
feat(tracing): add hook mechanism to deal with tracing

### DIFF
--- a/src/main/java/io/gravitee/gateway/reactive/api/ExecutionPhase.java
+++ b/src/main/java/io/gravitee/gateway/reactive/api/ExecutionPhase.java
@@ -49,7 +49,7 @@ public enum ExecutionPhase {
      *
      * For an HTTP request, it represents the policies executed <b>before</b> the endpoint is invoked by the gateway.
      */
-    REQUEST,
+    REQUEST("request"),
 
     /**
      * This phase represents the actions occurring from the downstream to the upstream in an async execution context.
@@ -64,7 +64,7 @@ public enum ExecutionPhase {
      *
      * </pre>
      */
-    ASYNC_REQUEST,
+    ASYNC_REQUEST("async_request"),
 
     /**
      * This phase represents the actions occurring from the upstream to the downstream in a sync execution context.
@@ -81,7 +81,7 @@ public enum ExecutionPhase {
      *
      * For an HTTP request, it represents the policies executed <b>after</b> the endpoint has been invoked by the gateway.
      */
-    RESPONSE,
+    RESPONSE("response"),
 
     /**
      * This phase represents the actions occurring from the upstream to the downstream in an async execution context.
@@ -96,5 +96,15 @@ public enum ExecutionPhase {
      *
      * </pre>
      */
-    ASYNC_RESPONSE,
+    ASYNC_RESPONSE("async_response");
+
+    private final String label;
+
+    ExecutionPhase(final String label) {
+        this.label = label;
+    }
+
+    public String getLabel() {
+        return label;
+    }
 }

--- a/src/main/java/io/gravitee/gateway/reactive/api/context/ExecutionContext.java
+++ b/src/main/java/io/gravitee/gateway/reactive/api/context/ExecutionContext.java
@@ -170,11 +170,4 @@ public interface ExecutionContext {
      * @return the El {@link TemplateEngine}.
      */
     TemplateEngine getTemplateEngine();
-
-    /**
-     * Get the {@link Tracer} that can be used to contribute to tracing.
-     *
-     * @return the {@link Tracer} associated to the current request.
-     */
-    Tracer getTracer();
 }

--- a/src/main/java/io/gravitee/gateway/reactive/api/hook/ChainHook.java
+++ b/src/main/java/io/gravitee/gateway/reactive/api/hook/ChainHook.java
@@ -1,0 +1,24 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gateway.reactive.api.hook;
+
+/**
+ * Interface that can be used to add hook behaviour on a chain
+ *
+ * @author Guillaume LAMIRAND (guillaume.lamirand at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+public interface ChainHook extends Hook {}

--- a/src/main/java/io/gravitee/gateway/reactive/api/hook/Hook.java
+++ b/src/main/java/io/gravitee/gateway/reactive/api/hook/Hook.java
@@ -1,0 +1,51 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gateway.reactive.api.hook;
+
+import io.gravitee.gateway.reactive.api.ExecutionFailure;
+import io.gravitee.gateway.reactive.api.ExecutionPhase;
+import io.gravitee.gateway.reactive.api.context.RequestExecutionContext;
+import io.reactivex.annotations.Nullable;
+
+/**
+ * Interface that can be used to add generic behaviour
+ *
+ * @author Guillaume LAMIRAND (guillaume.lamirand at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+public interface Hook {
+    String id();
+
+    default void pre(final String id, final RequestExecutionContext ctx, @Nullable final ExecutionPhase executionPhase) {}
+
+    default void post(final String id, final RequestExecutionContext ctx, @Nullable final ExecutionPhase executionPhase) {}
+
+    default void error(
+        final String id,
+        final RequestExecutionContext ctx,
+        @Nullable final ExecutionPhase executionPhase,
+        final Throwable throwable
+    ) {}
+
+    default void interrupt(final String id, final RequestExecutionContext ctx, @Nullable final ExecutionPhase executionPhase) {}
+
+    default void interruptWith(
+        final String id,
+        final RequestExecutionContext ctx,
+        @Nullable final ExecutionPhase executionPhase,
+        final ExecutionFailure failure
+    ) {}
+}

--- a/src/main/java/io/gravitee/gateway/reactive/api/hook/Hookable.java
+++ b/src/main/java/io/gravitee/gateway/reactive/api/hook/Hookable.java
@@ -1,0 +1,26 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gateway.reactive.api.hook;
+
+import java.util.List;
+
+/**
+ * @author Guillaume LAMIRAND (guillaume.lamirand at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+public interface Hookable<T> {
+    void addHooks(final List<T> hooks);
+}

--- a/src/main/java/io/gravitee/gateway/reactive/api/hook/InvokerHook.java
+++ b/src/main/java/io/gravitee/gateway/reactive/api/hook/InvokerHook.java
@@ -1,0 +1,22 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gateway.reactive.api.hook;
+
+/**
+ * @author Guillaume LAMIRAND (guillaume.lamirand at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+public interface InvokerHook extends Hook {}

--- a/src/main/java/io/gravitee/gateway/reactive/api/hook/MessageHook.java
+++ b/src/main/java/io/gravitee/gateway/reactive/api/hook/MessageHook.java
@@ -13,10 +13,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.gravitee.gateway.reactive.api.flow;
+package io.gravitee.gateway.reactive.api.hook;
 
 /**
- * @author Jeoffrey HAEYAERT (jeoffrey.haeyaert at graviteesource.com)
+ * Interface that can be used to add hook behaviour on messages
+ *
+ * @author Guillaume LAMIRAND (guillaume.lamirand at graviteesource.com)
  * @author GraviteeSource Team
  */
-public interface FlowChain {}
+public interface MessageHook extends Hook {}

--- a/src/main/java/io/gravitee/gateway/reactive/api/hook/PolicyHook.java
+++ b/src/main/java/io/gravitee/gateway/reactive/api/hook/PolicyHook.java
@@ -1,0 +1,24 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gateway.reactive.api.hook;
+
+/**
+ * Interface that can be used to add hook behaviour while executing a policy phase
+ *
+ * @author Guillaume LAMIRAND (guillaume.lamirand at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+public interface PolicyHook extends Hook {}

--- a/src/main/java/io/gravitee/gateway/reactive/api/hook/ProcessorHook.java
+++ b/src/main/java/io/gravitee/gateway/reactive/api/hook/ProcessorHook.java
@@ -1,0 +1,24 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gateway.reactive.api.hook;
+
+/**
+ * Interface that can be used to add hook behaviour on processors
+ *
+ * @author Guillaume LAMIRAND (guillaume.lamirand at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+public interface ProcessorHook extends Hook {}


### PR DESCRIPTION

**Description**

Add interface to be able to add extra behaviour while executing a component: chain, processor, policy or anything
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `1.33.0-prototype-reactive-tracing-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/gateway/gravitee-gateway-api/1.33.0-prototype-reactive-tracing-SNAPSHOT/gravitee-gateway-api-1.33.0-prototype-reactive-tracing-SNAPSHOT.zip)
  <!-- Version placeholder end -->
