### PR TITLE
feat: add managers for api key and subscription caches

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
 
     <groupId>io.gravitee.gateway</groupId>
     <artifactId>gravitee-gateway-api</artifactId>
-    <version>1.35.0</version>
+    <version>1.36.0-SNAPSHOT</version>
 
     <name>Gravitee.io APIM - Gateway - API</name>
 

--- a/src/main/java/io/gravitee/gateway/api/service/ApiKey.java
+++ b/src/main/java/io/gravitee/gateway/api/service/ApiKey.java
@@ -1,0 +1,111 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gateway.api.service;
+
+import java.util.Date;
+
+public class ApiKey {
+
+    private String id;
+
+    private String key;
+
+    private String api;
+
+    private String plan;
+
+    private String subscription;
+
+    private String application;
+
+    private Date expireAt;
+
+    private boolean revoked;
+
+    private boolean paused;
+
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    public String getKey() {
+        return key;
+    }
+
+    public void setKey(String key) {
+        this.key = key;
+    }
+
+    public String getApplication() {
+        return application;
+    }
+
+    public void setApplication(String application) {
+        this.application = application;
+    }
+
+    public Date getExpireAt() {
+        return expireAt;
+    }
+
+    public void setExpireAt(Date expireAt) {
+        this.expireAt = expireAt;
+    }
+
+    public boolean isRevoked() {
+        return revoked;
+    }
+
+    public void setRevoked(boolean revoked) {
+        this.revoked = revoked;
+    }
+
+    public boolean isPaused() {
+        return paused;
+    }
+
+    public void setPaused(boolean paused) {
+        this.paused = paused;
+    }
+
+    public String getApi() {
+        return api;
+    }
+
+    public void setApi(String api) {
+        this.api = api;
+    }
+
+    public String getPlan() {
+        return plan;
+    }
+
+    public void setPlan(String plan) {
+        this.plan = plan;
+    }
+
+    public String getSubscription() {
+        return subscription;
+    }
+
+    public void setSubscription(String subscription) {
+        this.subscription = subscription;
+    }
+}

--- a/src/main/java/io/gravitee/gateway/api/service/ApiKeyService.java
+++ b/src/main/java/io/gravitee/gateway/api/service/ApiKeyService.java
@@ -1,0 +1,40 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gateway.api.service;
+
+import java.util.Optional;
+
+/**
+ * This manages api keys.
+ */
+public interface ApiKeyService {
+    /**
+     * Save the given api key.
+     * Will put it in cache if active, or remove it from cache elsewhere.
+     *
+     * @param apiKey the api key to save
+     */
+    void save(ApiKey apiKey);
+
+    /**
+     * Get api key by its api and key.
+     *
+     * @param api Searched api
+     * @param key Searched key
+     * @return Found ApiKey
+     */
+    Optional<ApiKey> getByApiAndKey(String api, String key);
+}

--- a/src/main/java/io/gravitee/gateway/api/service/Subscription.java
+++ b/src/main/java/io/gravitee/gateway/api/service/Subscription.java
@@ -1,0 +1,106 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gateway.api.service;
+
+import java.util.Date;
+
+public class Subscription {
+
+    private String id;
+
+    private String api;
+
+    private String plan;
+
+    private String application;
+
+    private String clientId;
+
+    private String status;
+
+    private Date startingAt;
+
+    private Date endingAt;
+
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    public String getApi() {
+        return api;
+    }
+
+    public void setApi(String api) {
+        this.api = api;
+    }
+
+    public String getPlan() {
+        return plan;
+    }
+
+    public void setPlan(String plan) {
+        this.plan = plan;
+    }
+
+    public String getClientId() {
+        return clientId;
+    }
+
+    public void setClientId(String clientId) {
+        this.clientId = clientId;
+    }
+
+    public String getStatus() {
+        return status;
+    }
+
+    public void setStatus(String status) {
+        this.status = status;
+    }
+
+    public Date getStartingAt() {
+        return startingAt;
+    }
+
+    public void setStartingAt(Date startingAt) {
+        this.startingAt = startingAt;
+    }
+
+    public Date getEndingAt() {
+        return endingAt;
+    }
+
+    public void setEndingAt(Date endingAt) {
+        this.endingAt = endingAt;
+    }
+
+    public String getApplication() {
+        return application;
+    }
+
+    public void setApplication(String application) {
+        this.application = application;
+    }
+
+    public boolean isTimeValid(long requestTimestamp) {
+        Date requestDate = new Date(requestTimestamp);
+        return (endingAt == null || endingAt.after(requestDate)) && (startingAt == null || startingAt.before(requestDate));
+    }
+}

--- a/src/main/java/io/gravitee/gateway/api/service/SubscriptionService.java
+++ b/src/main/java/io/gravitee/gateway/api/service/SubscriptionService.java
@@ -1,0 +1,48 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gateway.api.service;
+
+import java.util.Optional;
+
+/**
+ * This manages subscriptions.
+ */
+public interface SubscriptionService {
+    /**
+     * Save the given subscription.
+     * Will put it in cache if active, or remove it from cache elsewhere.
+     *
+     * @param subscription the subscription to save
+     */
+    void save(Subscription subscription);
+
+    /**
+     * Get subscription by its API and client ID.
+     *
+     * @param api Searched API
+     * @param clientId Searched client ID
+     * @return Found subscription
+     */
+    Optional<Subscription> getByApiAndClientId(String api, String clientId);
+
+    /**
+     * Get subscription by its ID.
+     *
+     * @param subscriptionId Searched subscription ID
+     * @return Found subscription
+     */
+    Optional<Subscription> getById(String subscriptionId);
+}

--- a/src/test/java/io/gravitee/gateway/api/service/SubscriptionTest.java
+++ b/src/test/java/io/gravitee/gateway/api/service/SubscriptionTest.java
@@ -1,0 +1,72 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gateway.api.service;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.sql.Date;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import org.junit.jupiter.api.Test;
+
+public class SubscriptionTest {
+
+    @Test
+    public void isTimeValid_should_return_false_cause_not_yet_started() {
+        Subscription subscription = new Subscription();
+        subscription.setStartingAt(Date.from(Instant.now().plus(1, ChronoUnit.DAYS)));
+        subscription.setEndingAt(Date.from(Instant.now().plus(2, ChronoUnit.DAYS)));
+
+        assertFalse(subscription.isTimeValid(Date.from(Instant.now()).getTime()));
+    }
+
+    @Test
+    public void isTimeValid_should_return_false_cause_already_expired() {
+        Subscription subscription = new Subscription();
+        subscription.setStartingAt(Date.from(Instant.now().minus(2, ChronoUnit.DAYS)));
+        subscription.setEndingAt(Date.from(Instant.now().minus(1, ChronoUnit.DAYS)));
+
+        assertFalse(subscription.isTimeValid(Date.from(Instant.now()).getTime()));
+    }
+
+    @Test
+    public void isTimeValid_should_return_true_cause_between_start_and_end() {
+        Subscription subscription = new Subscription();
+        subscription.setStartingAt(Date.from(Instant.now().minus(1, ChronoUnit.DAYS)));
+        subscription.setEndingAt(Date.from(Instant.now().plus(1, ChronoUnit.DAYS)));
+
+        assertTrue(subscription.isTimeValid(Date.from(Instant.now()).getTime()));
+    }
+
+    @Test
+    public void isTimeValid_should_return_true_with_null_start_date() {
+        Subscription subscription = new Subscription();
+        subscription.setStartingAt(null);
+        subscription.setEndingAt(Date.from(Instant.now().plus(1, ChronoUnit.DAYS)));
+
+        assertTrue(subscription.isTimeValid(Date.from(Instant.now()).getTime()));
+    }
+
+    @Test
+    public void isTimeValid_should_return_true_with_null_end_date() {
+        Subscription subscription = new Subscription();
+        subscription.setStartingAt(Date.from(Instant.now().minus(1, ChronoUnit.DAYS)));
+        subscription.setEndingAt(null);
+
+        assertTrue(subscription.isTimeValid(Date.from(Instant.now()).getTime()));
+    }
+}


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/issues/issues/7360

**Description**

This adds services to manage subscriptions and api keys.

Policies should never access to underlying repository directly,
So they will use those cache managers instead of repositoryWrappers.
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `1.36.0-refactor-apiKeysAndSubsManagers-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/gateway/gravitee-gateway-api/1.36.0-refactor-apiKeysAndSubsManagers-SNAPSHOT/gravitee-gateway-api-1.36.0-refactor-apiKeysAndSubsManagers-SNAPSHOT.zip)
  <!-- Version placeholder end -->
