### PR TITLE
fix: restore HTTP headers backward compatibility

### DIFF
--- a/src/main/java/io/gravitee/gateway/api/http/DefaultHttpHeaders.java
+++ b/src/main/java/io/gravitee/gateway/api/http/DefaultHttpHeaders.java
@@ -16,13 +16,22 @@
 package io.gravitee.gateway.api.http;
 
 import io.gravitee.common.util.LinkedCaseInsensitiveMap;
-import java.util.*;
+import io.gravitee.common.util.MultiValueMap;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
 /**
+ * Implements {@link MultiValueMap<String,String>} for backward compatibility.
  * @author David BRASSELY (david.brassely at graviteesource.com)
  * @author GraviteeSource Team
  */
-public class DefaultHttpHeaders implements io.gravitee.gateway.api.http.HttpHeaders {
+public class DefaultHttpHeaders implements io.gravitee.gateway.api.http.HttpHeaders, MultiValueMap<String, String> {
 
     private final Map<String, List<String>> headers;
 
@@ -137,7 +146,7 @@ public class DefaultHttpHeaders implements io.gravitee.gateway.api.http.HttpHead
     }
 
     @Override
-    public Iterator<Map.Entry<String, String>> iterator() {
+    public Iterator<Entry<String, String>> iterator() {
         final Iterator<Map.Entry<String, List<String>>> entries = headers.entrySet().iterator();
 
         return new Iterator<>() {
@@ -167,5 +176,101 @@ public class DefaultHttpHeaders implements io.gravitee.gateway.api.http.HttpHead
                 };
             }
         };
+    }
+
+    @Override
+    public Map<String, String> toSingleValueMap() {
+        return HttpHeaders.super.toSingleValueMap();
+    }
+
+    @Override
+    public boolean containsAllKeys(Collection<String> names) {
+        return HttpHeaders.super.containsAllKeys(names);
+    }
+
+    @Override
+    public boolean containsKey(Object key) {
+        return headers.containsKey(key);
+    }
+
+    @Override
+    public boolean containsValue(Object value) {
+        return headers.containsValue(value);
+    }
+
+    /**
+     * @see LinkedCaseInsensitiveMap#get(Object)
+     * Contrary to {@link DefaultHttpHeaders#get(CharSequence)}, the list of values is returned, not only the first element
+     */
+    @Override
+    public List<String> get(Object key) {
+        final List<String> values = headers.get(key);
+        return values == null ? Collections.emptyList() : values;
+    }
+
+    /**
+     * @see HashMap#putVal(int, Object, Object, boolean, boolean), returns the previous value if present, else null.
+     */
+    @Override
+    public List<String> put(String key, List<String> value) {
+        return headers.put(key, value);
+    }
+
+    /**
+     * @see HashMap#remove(Object), returns the previous value (can bee {@code null}) associated with {@code key} or null if none.
+     */
+    @Override
+    public List<String> remove(Object key) {
+        return headers.remove(key);
+    }
+
+    @Override
+    public void putAll(Map<? extends String, ? extends List<String>> map) {
+        headers.putAll(map);
+    }
+
+    @Override
+    public Set<String> keySet() {
+        return headers.keySet();
+    }
+
+    @Override
+    public Collection<List<String>> values() {
+        return headers.values();
+    }
+
+    @Override
+    public Set<Entry<String, List<String>>> entrySet() {
+        return headers.entrySet();
+    }
+
+    @Override
+    public String getFirst(String header) {
+        List<String> headerValues = this.headers.get(header);
+        return (headerValues != null ? headerValues.get(0) : null);
+    }
+
+    @Override
+    public void add(String name, String value) {
+        List<String> headerValues = this.headers.get(name);
+        if (headerValues == null) {
+            headerValues = new LinkedList<>();
+            this.headers.put(name, headerValues);
+        }
+        headerValues.add(value);
+    }
+
+    @Override
+    public void set(String name, String value) {
+        List<String> headerValues = new LinkedList<String>();
+        headerValues.add(value);
+        this.headers.put(name, headerValues);
+    }
+
+    @Override
+    public void setAll(Map<String, String> values) {
+        for (Entry<String, String> entry : values.entrySet()) {
+            set(entry.getKey(), entry.getValue());
+        }
     }
 }

--- a/src/main/java/io/gravitee/gateway/api/http/HttpHeaders.java
+++ b/src/main/java/io/gravitee/gateway/api/http/HttpHeaders.java
@@ -15,7 +15,11 @@
  */
 package io.gravitee.gateway.api.http;
 
-import java.util.*;
+import java.util.Collection;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 /**
@@ -41,10 +45,18 @@ public interface HttpHeaders extends Iterable<Map.Entry<String, String>> {
      * @deprecated
      */
     default boolean containsKey(CharSequence name) {
+        return containsKey(String.valueOf(name));
+    }
+
+    default boolean containsKey(String name) {
         return contains(name);
     }
 
     boolean contains(CharSequence name);
+
+    default boolean contains(String name) {
+        return contains((CharSequence) name);
+    }
 
     Set<String> names();
 
@@ -69,7 +81,7 @@ public interface HttpHeaders extends Iterable<Map.Entry<String, String>> {
 
     default List<String> getOrDefault(CharSequence key, List<String> defaultValue) {
         List<String> v;
-        return (((v = getAll(key)) != null) || containsKey(key)) ? v : defaultValue;
+        return (((v = getAll(key)) != null) || containsKey(key.toString())) ? v : defaultValue;
     }
 
     static HttpHeaders create() {
@@ -83,7 +95,7 @@ public interface HttpHeaders extends Iterable<Map.Entry<String, String>> {
     default Map<String, String> toSingleValueMap() {
         LinkedHashMap<String, String> singleValueMap = new LinkedHashMap<>(size());
         for (Map.Entry<String, String> entry : this) {
-            singleValueMap.put(entry.getKey(), entry.getValue());
+            singleValueMap.putIfAbsent(entry.getKey(), entry.getValue());
         }
         return singleValueMap;
     }

--- a/src/test/java/io/gravitee/gateway/api/http/DefaultHttpHeadersTest.java
+++ b/src/test/java/io/gravitee/gateway/api/http/DefaultHttpHeadersTest.java
@@ -1,0 +1,228 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gateway.api.http;
+
+import static io.gravitee.gateway.api.http.HttpHeaderNames.ACCEPT_LANGUAGE;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * @author Yann TAVERNIER (yann.tavernier at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+class DefaultHttpHeadersTest {
+
+    public static final String FIRST_HEADER = "First-Header";
+    public static final String SECOND_HEADER = "Second-Header";
+    public static final String FIRST_HEADER_VALUE_1 = "first-header-value-1";
+    public static final String FIRST_HEADER_VALUE_2 = "first-header-value-2";
+    public static final String SECOND_HEADER_VALUE = "second-header-value";
+    private DefaultHttpHeaders cut;
+
+    @BeforeEach
+    void setUp() {
+        cut = new DefaultHttpHeaders();
+        cut.add(FIRST_HEADER, FIRST_HEADER_VALUE_1);
+        cut.add(FIRST_HEADER, FIRST_HEADER_VALUE_2);
+        cut.add(SECOND_HEADER, SECOND_HEADER_VALUE);
+    }
+
+    @Test
+    @DisplayName("Should convert headers to single value map")
+    void shouldConvertToSingleValueMap() {
+        final Map<String, String> result = cut.toSingleValueMap();
+        assertThat(result).containsEntry(FIRST_HEADER, FIRST_HEADER_VALUE_1).containsEntry(SECOND_HEADER, SECOND_HEADER_VALUE);
+
+        // In case of multiple values for one header name, this conversion is only taking the first value
+        assertThat(result.values()).doesNotContain(FIRST_HEADER_VALUE_2);
+    }
+
+    @Test
+    @DisplayName("Should contain all keys")
+    void shouldContainAllKeys() {
+        assertThat(cut.containsAllKeys(List.of())).isTrue();
+        assertThat(cut.containsAllKeys(List.of(FIRST_HEADER))).isTrue();
+        assertThat(cut.containsAllKeys(List.of(FIRST_HEADER, SECOND_HEADER))).isTrue();
+
+        assertThat(cut.containsAllKeys(List.of(FIRST_HEADER, SECOND_HEADER, ACCEPT_LANGUAGE))).isFalse();
+        assertThat(cut.containsAllKeys(List.of(ACCEPT_LANGUAGE))).isFalse();
+    }
+
+    @Test
+    @DisplayName("Should contain key")
+    void shouldContainKey() {
+        Object key = new Object();
+        assertThat(cut.containsKey(key)).isFalse();
+
+        key = FIRST_HEADER;
+        assertThat(cut.containsKey(key)).isTrue();
+
+        key = ACCEPT_LANGUAGE;
+        assertThat(cut.containsKey(key)).isFalse();
+    }
+
+    @Test
+    @DisplayName("Should contain value")
+    void shouldContainValue() {
+        Object value = new Object();
+        assertThat(cut.containsValue(value)).isFalse();
+
+        value = List.of(FIRST_HEADER_VALUE_1, FIRST_HEADER_VALUE_2);
+        assertThat(cut.containsValue(value)).isTrue();
+
+        value = List.of(SECOND_HEADER_VALUE);
+        assertThat(cut.containsValue(value)).isTrue();
+
+        value = List.of(ACCEPT_LANGUAGE);
+        assertThat(cut.containsValue(value)).isFalse();
+    }
+
+    @Test
+    @DisplayName("Should get values")
+    void shouldGet() {
+        Object key = new Object();
+        assertThat(cut.get(key)).isEmpty();
+
+        key = FIRST_HEADER;
+        assertThat(cut.get(key)).hasSize(2);
+
+        key = SECOND_HEADER;
+        assertThat(cut.get(key)).hasSize(1);
+
+        key = ACCEPT_LANGUAGE;
+        assertThat(cut.get(key)).isEmpty();
+    }
+
+    @Test
+    @DisplayName("Should put values")
+    void shouldPut() {
+        // Putting a new header
+        final List<String> headerTestValues = List.of("test-value1", "test-value2");
+        final List<String> testHeader = cut.put("test", headerTestValues);
+
+        assertThat(testHeader).isNull();
+        assertThat(cut.getAll("test")).isEqualTo(headerTestValues);
+        assertThat(cut.size()).isEqualTo(3);
+
+        // Putting a header already present in the map
+        final List<String> firstHeaderNewValues = List.of("first-overridden-1", "first-overridden-2", "first-overridden-3");
+        final List<String> firstHeaderOverridden = cut.put(FIRST_HEADER, firstHeaderNewValues);
+
+        assertThat(firstHeaderOverridden).hasSize(2).containsExactlyElementsOf(List.of(FIRST_HEADER_VALUE_1, FIRST_HEADER_VALUE_2));
+        assertThat(cut.getAll(FIRST_HEADER)).containsExactlyElementsOf(firstHeaderNewValues);
+    }
+
+    @Test
+    @DisplayName("Should remove header")
+    void shouldRemove() {
+        final HttpHeaders headers = cut.remove(FIRST_HEADER);
+        assertThat(headers.contains(FIRST_HEADER)).isFalse();
+    }
+
+    @Test
+    @DisplayName("Should put all")
+    void shouldPutAll() {
+        final List<String> putAllHeaders = List.of("test-value1", "test-value2");
+        final Map<String, List<String>> mapToAdd = Map.of("Put-All-Header", putAllHeaders, FIRST_HEADER, List.of("new-value"));
+
+        cut.putAll(mapToAdd);
+
+        assertThat(cut.getAll("Put-All-Header")).hasSize(2).containsExactlyElementsOf(putAllHeaders);
+
+        // Existing headers in the map should be overridden by this operation
+        assertThat(cut.getAll(FIRST_HEADER)).hasSize(1).containsExactly("new-value");
+    }
+
+    @Test
+    @DisplayName("Should get keySet")
+    void shouldGetKeySet() {
+        assertThat(cut.keySet()).hasSize(2).containsExactly(FIRST_HEADER, SECOND_HEADER);
+    }
+
+    @Test
+    @DisplayName("Should get values")
+    void shouldGetValues() {
+        assertThat(cut.values())
+            .hasSize(2)
+            .containsExactly(List.of(FIRST_HEADER_VALUE_1, FIRST_HEADER_VALUE_2), List.of(SECOND_HEADER_VALUE));
+    }
+
+    @Test
+    @DisplayName("Should get entrySet")
+    void shouldGetEntrySet() {
+        assertThat(cut.entrySet())
+            .hasSize(2)
+            .containsExactly(
+                Map.entry(FIRST_HEADER, List.of(FIRST_HEADER_VALUE_1, FIRST_HEADER_VALUE_2)),
+                Map.entry(SECOND_HEADER, List.of(SECOND_HEADER_VALUE))
+            );
+    }
+
+    @Test
+    @DisplayName("Should get first")
+    void shouldGetFirst() {
+        assertThat(cut.getFirst(FIRST_HEADER)).isEqualTo(FIRST_HEADER_VALUE_1);
+    }
+
+    @Test
+    @DisplayName("Should not get first when absent")
+    void shouldNotGetFirst() {
+        assertThat(cut.getFirst("Content-Type")).isNull();
+    }
+
+    @Test
+    @DisplayName("Should add value for an existing key")
+    void shouldAddValue() {
+        cut.add(FIRST_HEADER, "new-value");
+        assertThat(cut.getAll(FIRST_HEADER)).hasSize(3).containsExactly(FIRST_HEADER_VALUE_1, FIRST_HEADER_VALUE_2, "new-value");
+    }
+
+    @Test
+    @DisplayName("Should add value for a non existing key")
+    void shouldAddValueNonExistingKey() {
+        cut.add("New-Header", "new-value");
+        assertThat(cut.getAll("New-Header")).hasSize(1).containsExactly("new-value");
+    }
+
+    @Test
+    @DisplayName("Should set value and override if present")
+    void shouldSetValue() {
+        cut.set(FIRST_HEADER, "new-value");
+        cut.set("New-Header", "new-value");
+
+        assertThat(cut.getAll(FIRST_HEADER)).hasSize(1).containsExactly("new-value");
+
+        assertThat(cut.getAll("New-Header")).hasSize(1).containsExactly("new-value");
+    }
+
+    @Test
+    @DisplayName("Should set all values and override if present")
+    void shouldSetAll() {
+        final Map<String, String> mapToAdd = Map.of("Put-All-Header", "test-value1", FIRST_HEADER, "new-value");
+
+        cut.setAll(mapToAdd);
+
+        assertThat(cut.getAll("Put-All-Header")).hasSize(1).containsExactly("test-value1");
+
+        // Existing headers in the map should be overridden by this operation
+        assertThat(cut.getAll(FIRST_HEADER)).hasSize(1).containsExactly("new-value");
+    }
+}

--- a/src/test/java/io/gravitee/gateway/api/http/HttpHeadersTest.java
+++ b/src/test/java/io/gravitee/gateway/api/http/HttpHeadersTest.java
@@ -47,7 +47,10 @@ public class HttpHeadersTest {
     private static Stream<Arguments> provideHttpHeadersDataForDeeplyEqualsTest() {
         return Stream.of(
             Arguments.of(
-                HttpHeaders.create().add("Host", "test.gravitee.io").add("Accept", List.of("application/json", "application/json+vnd")),
+                HttpHeaders
+                    .create()
+                    .add((CharSequence) "Host", "test.gravitee.io")
+                    .add("Accept", List.of("application/json", "application/json+vnd")),
                 HttpHeaders.create().add("Host", "test.gravitee.io").add("Accept", List.of("application/json", "application/json+vnd")),
                 true,
                 "HttpHeaders are equals"


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/issues/issues/7812

**Description**

3.15 introduced a refactoring of the HTTP Headers used in the Gateway. It does not rely on gravitee-common `HTTPHeaders` anymore but on gateway-api HTTPHeaders.

This new version is used as an `Iterable<Map.Entry<String, String>>`, breaking the contract for users using `MultiValueMap<String, String>` methods, or multi value capabilities.

To not break this new contract and open the possibilities too wildly to the policies relying on it, `MultiValueMap` is implemented at implementation level, to keep the "old behavior" only internally
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `1.32.3-issues-7812-retro-headers-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/gateway/gravitee-gateway-api/1.32.3-issues-7812-retro-headers-SNAPSHOT/gravitee-gateway-api-1.32.3-issues-7812-retro-headers-SNAPSHOT.zip)
  <!-- Version placeholder end -->
