### PR TITLE
fix: properly name onChunks method

### DIFF
--- a/src/main/java/io/gravitee/gateway/jupiter/api/context/Request.java
+++ b/src/main/java/io/gravitee/gateway/jupiter/api/context/Request.java
@@ -187,8 +187,12 @@ public interface Request {
      *     request.body(Buffer.buffer("My custom content");
      * </code>
      *
-     * <b>WARN:</b> replacing the request body will "drain" the previous request that was in place but occurs outside the reactive chain.
-     * You should consider using {@link #onBody(MaybeTransformer)} to change the body during the chain execution.
+     * <b>WARN:</b>
+     * <ul>
+     *  <li>replacing the request body will <b>NOT</b> "drain" the previous request that was in place.</li>
+     *  <li>You <b>MUST</b> ensure to consume the previous body by yourself when using it.</li>
+     *  <li>You <b>SHOULD</b> consider using {@link #onBody(MaybeTransformer)} to change the body during the chain execution.</li>
+     * </ul>
      *
      * @see #onBody(MaybeTransformer)
      * @see #chunks(Flowable)
@@ -225,9 +229,14 @@ public interface Request {
      * Set the current request body chunks from a {@link Flowable} of {@link Buffer}.
      * This is useful to directly pump the upstream chunks to the downstream without having to load all the chunks in memory.
      *
-     * <b>WARN:</b> replacing the request body will <b>NOT</b> "drain" the previous request that was in place.
+     * <b>WARN:</b>
+     * <ul>
+     *  <li>replacing the request chunks will <b>NOT</b> "drain" the previous request that was in place.</li>
+     *  <li>You <b>MUST</b> ensure to consume the previous chunks by yourself when using it.</li>
+     *  <li>You <b>SHOULD</b> consider using {@link #onChunks(FlowableTransformer)} to change the chunks during the chain execution.</li>
+     * </ul>
      *
-     * @param chunks the flowable of chunks representing the request body that will be pushed to the upstream.
+     * @param chunks the {@link Flowable} of chunks representing the request body that will be pushed to the upstream.
      *
      * @see #body()
      */
@@ -237,7 +246,7 @@ public interface Request {
      * Applies a transformation on each body chunks and completes when all the chunks have been processed.
      * Ex:
      * <code>
-     *     request.onChunk(chunks -> chunks.map(buffer -> Buffer.buffer(buffer.toString().toUpperCase())));
+     *     request.onChunks(chunks -> chunks.map(buffer -> Buffer.buffer(buffer.toString().toUpperCase())));
      * </code>
      *
      * <b>IMPORTANT: applying a transformation on the body chunks loads the whole body in memory.
@@ -246,8 +255,8 @@ public interface Request {
      * <b>IMPORTANT: applying a transformation on chunks completes when all chunks have been transformed.
      * If used in a policy chain, it means that the next policy will start once all chunks have been transformed</b>
      *
-     * @param onChunk the transformer that will be applied.
+     * @param onChunks the transformer that will be applied.
      * @return a {@link Completable} that completes once the body transformation has occurred on all the chunks.
      */
-    Completable onChunk(final FlowableTransformer<Buffer, Buffer> onChunk);
+    Completable onChunks(final FlowableTransformer<Buffer, Buffer> onChunks);
 }

--- a/src/main/java/io/gravitee/gateway/jupiter/api/context/Response.java
+++ b/src/main/java/io/gravitee/gateway/jupiter/api/context/Response.java
@@ -78,8 +78,12 @@ public interface Response {
      *     response.body(Buffer.buffer("My custom content");
      * </code>
      *
-     <b>WARN:</b> replacing the request body will "drain" the previous request that was in place but occurs outside the reactive chain.
-     * You should consider using {@link #onBody(MaybeTransformer)} to change the body during the chain execution.
+     * <b>WARN:</b>
+     * <ul>
+     *  <li>replacing the request body will <b>NOT</b> "drain" the previous request that was in place.</li>
+     *  <li>You <b>MUST</b> ensure to consume the previous body by yourself when using it.</li>
+     *  <li>You <b>SHOULD</b> consider using {@link #onBody(MaybeTransformer)} to change the body during the chain execution.</li>
+     * </ul>
      *
      * @see #onBody(MaybeTransformer)
      * @see #chunks(Flowable)
@@ -105,10 +109,15 @@ public interface Response {
     /**
      * Set the current response body chunks from a {@link Flowable} of {@link Buffer}.
      * This is useful to directly pump the upstream chunks to the downstream without having to load all the chunks in memory.
-     * <br/>
-     * <b>WARN:</b> replacing the response body will "drain" the previous response that was in place.
      *
-     * @param chunks the flowable of chunks representing the response to push back to the downstream.
+     * <b>WARN:</b>
+     * <ul>
+     *  <li>replacing the response chunks will <b>NOT</b> "drain" the previous response that was in place.</li>
+     *  <li>You <b>MUST</b> ensure to consume the previous chunks by yourself when using it.</li>
+     *  <li>You <b>SHOULD</b> consider using {@link #onChunks(FlowableTransformer)} to change the chunks during the chain execution.</li>
+     * </ul>
+     *
+     * @param chunks the {@link Flowable} of chunks representing the response to push back to the downstream.
      *
      * @see #body()
      */
@@ -128,7 +137,7 @@ public interface Response {
      * Applies a transformation on each body chunks and completes when all the chunks have been processed.
      * Ex:
      * <code>
-     *     response.onChunk(chunks -> chunks.map(buffer -> Buffer.buffer(buffer.toString().toUpperCase())));
+     *     response.onChunks(chunks -> chunks.map(buffer -> Buffer.buffer(buffer.toString().toUpperCase())));
      * </code>
      *
      * <b>IMPORTANT: applying a transformation on the body chunks loads the whole body in memory.
@@ -137,10 +146,10 @@ public interface Response {
      * <b>IMPORTANT: applying a transformation on chunks completes when all chunks have been transformed.
      * If used in a policy chain, it means that the next policy will start once all chunks have been transformed</b>
      *
-     * @param onChunk the transformer that will be applied.
+     * @param onChunks the transformer that will be applied.
      * @return a {@link Completable} that completes once the body transformation has occurred on all the chunks.
      */
-    Completable onChunk(final FlowableTransformer<Buffer, Buffer> onChunk);
+    Completable onChunks(final FlowableTransformer<Buffer, Buffer> onChunks);
 
     /**
      * End the response.


### PR DESCRIPTION
**Issue**

gravitee-io/issues#8030

**Description**

While working on the issue I wanted to add some javadoc details to better explain how request / response body or chunks can be consumed. I found that the `onChunk(...)` method wasn't well name and renamed it to` onChunks(...)` (with an 's' to be aligned with the wording). 

This can be considered as a breaking change but it is measured because Jupiter is still in its **alpha** version and, currently, only few policies have been migrated and they are not relying on the `onChunks(...)` method. We can consider it safe to make this change without taking care of the backward compatibility for now.