### PR TITLE
fix: return null instead of empty list when getting an undefined header

### DIFF
--- a/src/main/java/io/gravitee/gateway/api/http/DefaultHttpHeaders.java
+++ b/src/main/java/io/gravitee/gateway/api/http/DefaultHttpHeaders.java
@@ -204,8 +204,7 @@ public class DefaultHttpHeaders implements io.gravitee.gateway.api.http.HttpHead
      */
     @Override
     public List<String> get(Object key) {
-        final List<String> values = headers.get(key);
-        return values == null ? Collections.emptyList() : values;
+        return headers.get(key);
     }
 
     /**

--- a/src/test/java/io/gravitee/gateway/api/http/DefaultHttpHeadersTest.java
+++ b/src/test/java/io/gravitee/gateway/api/http/DefaultHttpHeadersTest.java
@@ -99,7 +99,7 @@ class DefaultHttpHeadersTest {
     @DisplayName("Should get values")
     void shouldGet() {
         Object key = new Object();
-        assertThat(cut.get(key)).isEmpty();
+        assertThat(cut.get(key)).isNull();
 
         key = FIRST_HEADER;
         assertThat(cut.get(key)).hasSize(2);
@@ -108,7 +108,7 @@ class DefaultHttpHeadersTest {
         assertThat(cut.get(key)).hasSize(1);
 
         key = ACCEPT_LANGUAGE;
-        assertThat(cut.get(key)).isEmpty();
+        assertThat(cut.get(key)).isNull();
     }
 
     @Test


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/issues/issues/7812
https://github.com/gravitee-io/issues/issues/8153

**Description**

Return null instead of an empty list when getting an undefined header.
Returning an empty list is causing the following EL to be evaluated to `true`:
`{#request.headers['X-Gravitee-No-Present'] != null}`
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `1.32.4-7812-fix-get-value-without-the-header-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/gateway/gravitee-gateway-api/1.32.4-7812-fix-get-value-without-the-header-SNAPSHOT/gravitee-gateway-api-1.32.4-7812-fix-get-value-without-the-header-SNAPSHOT.zip)
  <!-- Version placeholder end -->
