### PR TITLE
fix: SubscriptionService searches a subscription from a given API, client_id, and plan

### DIFF
--- a/src/main/java/io/gravitee/gateway/api/service/SubscriptionService.java
+++ b/src/main/java/io/gravitee/gateway/api/service/SubscriptionService.java
@@ -30,13 +30,14 @@ public interface SubscriptionService {
     void save(Subscription subscription);
 
     /**
-     * Get subscription by its API and client ID.
+     * Get subscription by its API, client ID, and plan.
      *
      * @param api Searched API
      * @param clientId Searched client ID
+     * @param plan Searched plan ID
      * @return Found subscription
      */
-    Optional<Subscription> getByApiAndClientId(String api, String clientId);
+    Optional<Subscription> getByApiAndClientIdAndPlan(String api, String clientId, String plan);
 
     /**
      * Get subscription by its ID.


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/issues/issues/8232

**Description**

fix: SubscriptionService searches a subscription from a given API, client_id, and plan

In 3.19, we replaced the SubscriptionRepositoryWrapper by a SubscriptionService, handling subscriptions.

This introduced a regression :
API and client_id wasn't an enough precise criteria to precisely find a subscription : this fixes adds the plan criteria.

<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `1.37.3-fix-fixSubscriptionCache-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/gateway/gravitee-gateway-api/1.37.3-fix-fixSubscriptionCache-SNAPSHOT/gravitee-gateway-api-1.37.3-fix-fixSubscriptionCache-SNAPSHOT.zip)
  <!-- Version placeholder end -->
