### PR TITLE
feat(message): access body from MessageRequest

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
 
     <groupId>io.gravitee.gateway</groupId>
     <artifactId>gravitee-gateway-api</artifactId>
-    <version>1.40.0</version>
+    <version>1.41.0-8036-http-post-entrypoint-SNAPSHOT</version>
 
     <name>Gravitee.io APIM - Gateway - API</name>
 

--- a/src/main/java/io/gravitee/gateway/jupiter/api/context/MessageRequest.java
+++ b/src/main/java/io/gravitee/gateway/jupiter/api/context/MessageRequest.java
@@ -16,17 +16,18 @@
 package io.gravitee.gateway.jupiter.api.context;
 
 import io.gravitee.gateway.api.buffer.Buffer;
-import io.gravitee.gateway.jupiter.api.context.HttpRequest;
 import io.gravitee.gateway.jupiter.api.message.Message;
 import io.reactivex.Completable;
 import io.reactivex.Flowable;
 import io.reactivex.FlowableTransformer;
+import io.reactivex.Maybe;
 
 /**
  * @author Guillaume LAMIRAND (guillaume.lamirand at graviteesource.com)
  * @author GraviteeSource Team
  */
 public interface MessageRequest extends HttpRequest {
+    Maybe<Buffer> body();
     Flowable<Message> messages();
     void messages(final Flowable<Message> messages);
     Completable onMessages(final FlowableTransformer<Message, Message> onMessages);


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/issues/issues/8036

**Description**

Adding a body method to the `MessageRequest` so we can access to the body content of an incoming request
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `1.41.0-8036-http-post-entrypoint-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/gateway/gravitee-gateway-api/1.41.0-8036-http-post-entrypoint-SNAPSHOT/gravitee-gateway-api-1.41.0-8036-http-post-entrypoint-SNAPSHOT.zip)
  <!-- Version placeholder end -->
