### PR TITLE
fix(request): move body() from Message to Http

### DIFF
--- a/src/main/java/io/gravitee/gateway/jupiter/api/context/HttpRequest.java
+++ b/src/main/java/io/gravitee/gateway/jupiter/api/context/HttpRequest.java
@@ -18,8 +18,10 @@ package io.gravitee.gateway.jupiter.api.context;
 import io.gravitee.common.http.HttpMethod;
 import io.gravitee.common.http.HttpVersion;
 import io.gravitee.common.util.MultiValueMap;
+import io.gravitee.gateway.api.buffer.Buffer;
 import io.gravitee.gateway.api.http.HttpHeaders;
 import io.gravitee.reporter.api.http.Metrics;
+import io.reactivex.Maybe;
 import javax.net.ssl.SSLSession;
 
 public interface HttpRequest {
@@ -129,4 +131,9 @@ public interface HttpRequest {
      * @return <code>true</code> if the headers and body have been read, <code>false</code> else.
      */
     boolean ended();
+
+    /**
+     * @return the body of the request.
+     */
+    Maybe<Buffer> body();
 }

--- a/src/main/java/io/gravitee/gateway/jupiter/api/context/MessageRequest.java
+++ b/src/main/java/io/gravitee/gateway/jupiter/api/context/MessageRequest.java
@@ -15,19 +15,16 @@
  */
 package io.gravitee.gateway.jupiter.api.context;
 
-import io.gravitee.gateway.api.buffer.Buffer;
 import io.gravitee.gateway.jupiter.api.message.Message;
 import io.reactivex.Completable;
 import io.reactivex.Flowable;
 import io.reactivex.FlowableTransformer;
-import io.reactivex.Maybe;
 
 /**
  * @author Guillaume LAMIRAND (guillaume.lamirand at graviteesource.com)
  * @author GraviteeSource Team
  */
 public interface MessageRequest extends HttpRequest {
-    Maybe<Buffer> body();
     Flowable<Message> messages();
     void messages(final Flowable<Message> messages);
     Completable onMessages(final FlowableTransformer<Message, Message> onMessages);


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/issues/issues/8036

**Description**

Fix the previous commit by moving `body()` from `MessageRequest` to `HttpRequest`
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `1.41.1-8036-http-post-entrypoint-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/gateway/gravitee-gateway-api/1.41.1-8036-http-post-entrypoint-SNAPSHOT/gravitee-gateway-api-1.41.1-8036-http-post-entrypoint-SNAPSHOT.zip)
  <!-- Version placeholder end -->
