### PR TITLE
feat(kafka): add kafka endpoint

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
 
     <groupId>io.gravitee.gateway</groupId>
     <artifactId>gravitee-gateway-api</artifactId>
-    <version>1.41.1</version>
+    <version>1.42.0-8245-kafka-consumers-SNAPSHOT</version>
 
     <name>Gravitee.io APIM - Gateway - API</name>
 

--- a/src/main/java/io/gravitee/gateway/jupiter/api/connector/endpoint/async/EndpointAsyncConnector.java
+++ b/src/main/java/io/gravitee/gateway/jupiter/api/connector/endpoint/async/EndpointAsyncConnector.java
@@ -15,7 +15,13 @@
  */
 package io.gravitee.gateway.jupiter.api.connector.endpoint.async;
 
+import io.gravitee.gateway.jupiter.api.ApiType;
 import io.gravitee.gateway.jupiter.api.connector.endpoint.EndpointConnector;
 import io.gravitee.gateway.jupiter.api.context.MessageExecutionContext;
 
-public interface EndpointAsyncConnector extends EndpointConnector<MessageExecutionContext> {}
+public interface EndpointAsyncConnector extends EndpointConnector<MessageExecutionContext> {
+    @Override
+    default ApiType supportedApi() {
+        return ApiType.ASYNC;
+    }
+}

--- a/src/main/java/io/gravitee/gateway/jupiter/api/connector/endpoint/async/EndpointAsyncConnectorFactory.java
+++ b/src/main/java/io/gravitee/gateway/jupiter/api/connector/endpoint/async/EndpointAsyncConnectorFactory.java
@@ -15,11 +15,17 @@
  */
 package io.gravitee.gateway.jupiter.api.connector.endpoint.async;
 
+import io.gravitee.gateway.jupiter.api.ApiType;
 import io.gravitee.gateway.jupiter.api.connector.AbstractConnectorFactory;
 
 public abstract class EndpointAsyncConnectorFactory extends AbstractConnectorFactory<EndpointAsyncConnector> {
 
-    public EndpointAsyncConnectorFactory(Class<?> configurationClass) {
+    protected EndpointAsyncConnectorFactory(Class<?> configurationClass) {
         super(configurationClass);
+    }
+
+    @Override
+    public ApiType supportedApi() {
+        return ApiType.ASYNC;
     }
 }

--- a/src/main/java/io/gravitee/gateway/jupiter/api/connector/endpoint/sync/EndpointSyncConnector.java
+++ b/src/main/java/io/gravitee/gateway/jupiter/api/connector/endpoint/sync/EndpointSyncConnector.java
@@ -15,7 +15,13 @@
  */
 package io.gravitee.gateway.jupiter.api.connector.endpoint.sync;
 
+import io.gravitee.gateway.jupiter.api.ApiType;
 import io.gravitee.gateway.jupiter.api.connector.endpoint.EndpointConnector;
 import io.gravitee.gateway.jupiter.api.context.RequestExecutionContext;
 
-public interface EndpointSyncConnector extends EndpointConnector<RequestExecutionContext> {}
+public interface EndpointSyncConnector extends EndpointConnector<RequestExecutionContext> {
+    @Override
+    default ApiType supportedApi() {
+        return ApiType.SYNC;
+    }
+}

--- a/src/main/java/io/gravitee/gateway/jupiter/api/connector/endpoint/sync/EndpointSyncConnectorFactory.java
+++ b/src/main/java/io/gravitee/gateway/jupiter/api/connector/endpoint/sync/EndpointSyncConnectorFactory.java
@@ -15,18 +15,24 @@
  */
 package io.gravitee.gateway.jupiter.api.connector.endpoint.sync;
 
+import io.gravitee.gateway.jupiter.api.ApiType;
 import io.gravitee.gateway.jupiter.api.ConnectorMode;
 import io.gravitee.gateway.jupiter.api.connector.AbstractConnectorFactory;
 import java.util.Set;
 
 public abstract class EndpointSyncConnectorFactory extends AbstractConnectorFactory<EndpointSyncConnector> {
 
-    public EndpointSyncConnectorFactory(Class<?> configurationClass) {
+    protected EndpointSyncConnectorFactory(Class<?> configurationClass) {
         super(configurationClass);
     }
 
     @Override
     public Set<ConnectorMode> supportedModes() {
         return Set.of(ConnectorMode.REQUEST_RESPONSE);
+    }
+
+    @Override
+    public ApiType supportedApi() {
+        return ApiType.SYNC;
     }
 }

--- a/src/main/java/io/gravitee/gateway/jupiter/api/connector/entrypoint/async/EntrypointAsyncConnector.java
+++ b/src/main/java/io/gravitee/gateway/jupiter/api/connector/entrypoint/async/EntrypointAsyncConnector.java
@@ -15,7 +15,13 @@
  */
 package io.gravitee.gateway.jupiter.api.connector.entrypoint.async;
 
+import io.gravitee.gateway.jupiter.api.ApiType;
 import io.gravitee.gateway.jupiter.api.connector.entrypoint.EntrypointConnector;
 import io.gravitee.gateway.jupiter.api.context.MessageExecutionContext;
 
-public interface EntrypointAsyncConnector extends EntrypointConnector<MessageExecutionContext> {}
+public interface EntrypointAsyncConnector extends EntrypointConnector<MessageExecutionContext> {
+    @Override
+    default ApiType supportedApi() {
+        return ApiType.ASYNC;
+    }
+}

--- a/src/main/java/io/gravitee/gateway/jupiter/api/connector/entrypoint/async/EntrypointAsyncConnectorFactory.java
+++ b/src/main/java/io/gravitee/gateway/jupiter/api/connector/entrypoint/async/EntrypointAsyncConnectorFactory.java
@@ -15,11 +15,17 @@
  */
 package io.gravitee.gateway.jupiter.api.connector.entrypoint.async;
 
+import io.gravitee.gateway.jupiter.api.ApiType;
 import io.gravitee.gateway.jupiter.api.connector.AbstractConnectorFactory;
 
 public abstract class EntrypointAsyncConnectorFactory extends AbstractConnectorFactory<EntrypointAsyncConnector> {
 
-    public EntrypointAsyncConnectorFactory(Class<?> configurationClass) {
+    protected EntrypointAsyncConnectorFactory(Class<?> configurationClass) {
         super(configurationClass);
+    }
+
+    @Override
+    public ApiType supportedApi() {
+        return ApiType.ASYNC;
     }
 }

--- a/src/main/java/io/gravitee/gateway/jupiter/api/connector/entrypoint/sync/EntrypointSyncConnector.java
+++ b/src/main/java/io/gravitee/gateway/jupiter/api/connector/entrypoint/sync/EntrypointSyncConnector.java
@@ -15,7 +15,13 @@
  */
 package io.gravitee.gateway.jupiter.api.connector.entrypoint.sync;
 
+import io.gravitee.gateway.jupiter.api.ApiType;
 import io.gravitee.gateway.jupiter.api.connector.entrypoint.EntrypointConnector;
 import io.gravitee.gateway.jupiter.api.context.RequestExecutionContext;
 
-public interface EntrypointSyncConnector extends EntrypointConnector<RequestExecutionContext> {}
+public interface EntrypointSyncConnector extends EntrypointConnector<RequestExecutionContext> {
+    @Override
+    default ApiType supportedApi() {
+        return ApiType.SYNC;
+    }
+}

--- a/src/main/java/io/gravitee/gateway/jupiter/api/connector/entrypoint/sync/EntrypointSyncConnectorFactory.java
+++ b/src/main/java/io/gravitee/gateway/jupiter/api/connector/entrypoint/sync/EntrypointSyncConnectorFactory.java
@@ -15,18 +15,24 @@
  */
 package io.gravitee.gateway.jupiter.api.connector.entrypoint.sync;
 
+import io.gravitee.gateway.jupiter.api.ApiType;
 import io.gravitee.gateway.jupiter.api.ConnectorMode;
 import io.gravitee.gateway.jupiter.api.connector.AbstractConnectorFactory;
 import java.util.Set;
 
 public abstract class EntrypointSyncConnectorFactory extends AbstractConnectorFactory<EntrypointSyncConnector> {
 
-    public EntrypointSyncConnectorFactory(Class<?> configurationClass) {
+    protected EntrypointSyncConnectorFactory(Class<?> configurationClass) {
         super(configurationClass);
     }
 
     @Override
     public Set<ConnectorMode> supportedModes() {
         return Set.of(ConnectorMode.REQUEST_RESPONSE);
+    }
+
+    @Override
+    public ApiType supportedApi() {
+        return ApiType.SYNC;
     }
 }

--- a/src/main/java/io/gravitee/gateway/jupiter/api/message/DefaultMessage.java
+++ b/src/main/java/io/gravitee/gateway/jupiter/api/message/DefaultMessage.java
@@ -1,0 +1,49 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gateway.jupiter.api.message;
+
+import io.gravitee.gateway.api.buffer.Buffer;
+import io.gravitee.gateway.api.http.HttpHeaders;
+import java.util.HashMap;
+import java.util.Map;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.NoArgsConstructor;
+
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class DefaultMessage implements Message {
+
+    private byte[] content;
+    private Map<String, Object> metadata = new HashMap<>();
+    private HttpHeaders headers = HttpHeaders.create();
+
+    @Override
+    public HttpHeaders headers() {
+        return headers;
+    }
+
+    @Override
+    public Map<String, Object> metadata() {
+        return metadata;
+    }
+
+    @Override
+    public Buffer content() {
+        return Buffer.buffer(content);
+    }
+}


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/issues/issues/8245
https://github.com/gravitee-io/issues/issues/8247

**Description**

Implement basic kafka endpoint for both subscribe and publish mode

**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `1.42.0-8245-kafka-consumers-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/gateway/gravitee-gateway-api/1.42.0-8245-kafka-consumers-SNAPSHOT/gravitee-gateway-api-1.42.0-8245-kafka-consumers-SNAPSHOT.zip)
  <!-- Version placeholder end -->
