### PR TITLE
feat(): add processor and error on async api

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,8 +29,7 @@
 
     <groupId>io.gravitee.gateway</groupId>
     <artifactId>gravitee-gateway-api</artifactId>
-    <version>1.48.0-develop-SNAPSHOT</version>
-
+    <version>1.48.0-8361-error-handling-SNAPSHOT</version>
     <name>Gravitee.io APIM - Gateway - API</name>
 
     <properties>

--- a/src/main/java/io/gravitee/gateway/jupiter/api/ExecutionFailure.java
+++ b/src/main/java/io/gravitee/gateway/jupiter/api/ExecutionFailure.java
@@ -16,11 +16,13 @@
 package io.gravitee.gateway.jupiter.api;
 
 import java.util.Map;
+import lombok.EqualsAndHashCode;
 
 /**
  * @author Jeoffrey HAEYAERT (jeoffrey.haeyaert at graviteesource.com)
  * @author GraviteeSource Team
  */
+@EqualsAndHashCode
 public class ExecutionFailure {
 
     private int statusCode;

--- a/src/main/java/io/gravitee/gateway/jupiter/api/connector/endpoint/sync/EndpointSyncConnector.java
+++ b/src/main/java/io/gravitee/gateway/jupiter/api/connector/endpoint/sync/EndpointSyncConnector.java
@@ -21,9 +21,10 @@ import io.gravitee.gateway.jupiter.api.connector.endpoint.EndpointConnector;
 /**
  * Specialized {@link EndpointConnector} for {@link ApiType#SYNC}
  */
-public interface EndpointSyncConnector extends EndpointConnector {
+public abstract class EndpointSyncConnector implements EndpointConnector {
+
     @Override
-    default ApiType supportedApi() {
+    public ApiType supportedApi() {
         return ApiType.SYNC;
     }
 }

--- a/src/main/java/io/gravitee/gateway/jupiter/api/connector/entrypoint/EntrypointConnector.java
+++ b/src/main/java/io/gravitee/gateway/jupiter/api/connector/entrypoint/EntrypointConnector.java
@@ -19,7 +19,6 @@ import io.gravitee.gateway.jupiter.api.ListenerType;
 import io.gravitee.gateway.jupiter.api.connector.Connector;
 import io.gravitee.gateway.jupiter.api.context.ExecutionContext;
 import io.reactivex.Completable;
-import java.util.Set;
 
 /**
  * Interface describing Entrypoint Connector which could be implemented to deal with new protocol specification

--- a/src/main/java/io/gravitee/gateway/jupiter/api/connector/entrypoint/async/EntrypointAsyncConnector.java
+++ b/src/main/java/io/gravitee/gateway/jupiter/api/connector/entrypoint/async/EntrypointAsyncConnector.java
@@ -21,9 +21,10 @@ import io.gravitee.gateway.jupiter.api.connector.entrypoint.EntrypointConnector;
 /**
  * Specialized {@link EntrypointConnector} for {@link ApiType#ASYNC}
  */
-public interface EntrypointAsyncConnector extends EntrypointConnector {
+public abstract class EntrypointAsyncConnector implements EntrypointConnector {
+
     @Override
-    default ApiType supportedApi() {
+    public ApiType supportedApi() {
         return ApiType.ASYNC;
     }
 }

--- a/src/main/java/io/gravitee/gateway/jupiter/api/connector/entrypoint/sync/EntrypointSyncConnector.java
+++ b/src/main/java/io/gravitee/gateway/jupiter/api/connector/entrypoint/sync/EntrypointSyncConnector.java
@@ -21,9 +21,10 @@ import io.gravitee.gateway.jupiter.api.connector.entrypoint.EntrypointConnector;
 /**
  * Specialized {@link EntrypointConnector} for {@link ApiType#SYNC}
  */
-public interface EntrypointSyncConnector extends EntrypointConnector {
+public abstract class EntrypointSyncConnector implements EntrypointConnector {
+
     @Override
-    default ApiType supportedApi() {
+    public ApiType supportedApi() {
         return ApiType.SYNC;
     }
 }

--- a/src/main/java/io/gravitee/gateway/jupiter/api/context/GenericExecutionContext.java
+++ b/src/main/java/io/gravitee/gateway/jupiter/api/context/GenericExecutionContext.java
@@ -36,17 +36,6 @@ public interface GenericExecutionContext {
      */
     GenericResponse response();
 
-    /**
-     * Interrupted the current execution while indicating that the response can be sent "as is" to the downstream.
-     * This has direct impact on how the remaining execution flow will behave (ex: remaining policies in a policy chain won't be executed).
-     */
-    Completable interrupt();
-
-    /**
-     * Same as {@link #interrupt()} but with an {@link ExecutionFailure} object that indicates that the execution has failed. The {@link ExecutionFailure} can be processed in order to build a proper response (ex: based on templating, with appropriate accept-encoding, ...).
-     */
-    Completable interruptWith(final ExecutionFailure failure);
-
     <T> T getComponent(Class<T> componentClass);
 
     /**

--- a/src/main/java/io/gravitee/gateway/jupiter/api/context/HttpExecutionContext.java
+++ b/src/main/java/io/gravitee/gateway/jupiter/api/context/HttpExecutionContext.java
@@ -15,6 +15,9 @@
  */
 package io.gravitee.gateway.jupiter.api.context;
 
+import io.gravitee.gateway.jupiter.api.ExecutionFailure;
+import io.reactivex.Completable;
+
 public interface HttpExecutionContext extends GenericExecutionContext {
     String TEMPLATE_ATTRIBUTE_REQUEST = "request";
     String TEMPLATE_ATTRIBUTE_RESPONSE = "response";
@@ -33,4 +36,15 @@ public interface HttpExecutionContext extends GenericExecutionContext {
      * @return the response attached to this execution context.
      */
     HttpResponse response();
+
+    /**
+     * Interrupted the current execution while indicating that the response can be sent "as is" to the downstream.
+     * This has direct impact on how the remaining execution flow will behave (ex: remaining policies in a policy chain won't be executed).
+     */
+    Completable interrupt();
+
+    /**
+     * Same as {@link #interrupt()} but with an {@link ExecutionFailure} object that indicates that the execution has failed. The {@link ExecutionFailure} can be processed in order to build a proper response (ex: based on templating, with appropriate accept-encoding, ...).
+     */
+    Completable interruptWith(final ExecutionFailure failure);
 }

--- a/src/main/java/io/gravitee/gateway/jupiter/api/context/InternalContextAttributes.java
+++ b/src/main/java/io/gravitee/gateway/jupiter/api/context/InternalContextAttributes.java
@@ -25,14 +25,16 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public final class InternalContextAttributes {
 
+    public static final String ATTR_INTERNAL_ENTRYPOINT_CONNECTOR = "entrypointConnector";
+    public static final String ATTR_INTERNAL_INVOKER = "invoker";
     public static final String ATTR_INTERNAL_EXECUTION_FAILURE = "executionFailure";
     public static final String ATTR_INTERNAL_FLOW_STAGE = "flow.stage";
+    public static final String ATTR_INTERNAL_SUBSCRIPTION = "subscription";
+    public static final String ATTR_INTERNAL_SUBSCRIPTION_TYPE = "subscription_type";
     /**
      * Adapted ExecutionContext for V3 compatibility.
      */
     public static final String ATTR_INTERNAL_ADAPTED_CONTEXT = "adaptedContext";
-    public static final String ATTR_INTERNAL_SUBSCRIPTION_TYPE = "subscription.type";
-    public static final String ATTR_INTERNAL_SUBSCRIPTION = "subscription";
 
     public static final String ATTR_INTERNAL_LISTENER_TYPE = "listener.type";
 

--- a/src/main/java/io/gravitee/gateway/jupiter/api/context/MessageExecutionContext.java
+++ b/src/main/java/io/gravitee/gateway/jupiter/api/context/MessageExecutionContext.java
@@ -15,6 +15,10 @@
  */
 package io.gravitee.gateway.jupiter.api.context;
 
+import io.gravitee.gateway.jupiter.api.ExecutionFailure;
+import io.gravitee.gateway.jupiter.api.message.Message;
+import io.reactivex.Flowable;
+
 public interface MessageExecutionContext extends GenericExecutionContext {
     /**
      * Get the current request stuck to this execution context.
@@ -29,4 +33,15 @@ public interface MessageExecutionContext extends GenericExecutionContext {
      * @return the response attached to this execution context.
      */
     MessageResponse response();
+
+    /**
+     * Interrupted the current execution while indicating that the flow of messages can be consumed "as is" to the downstream.
+     * This has direct impact on how the remaining execution flow will behave (ex: remaining policies in a policy chain won't be executed).
+     */
+    Flowable<Message> interruptMessages();
+
+    /**
+     * Same as {@link #interruptMessages()} but with an {@link ExecutionFailure} object that indicates that the execution has failed. The {@link ExecutionFailure} can be processed in order to build a proper response (ex: based on templating, with appropriate accept-encoding, ...).
+     */
+    Flowable<Message> interruptMessagesWith(final ExecutionFailure failure);
 }

--- a/src/main/java/io/gravitee/gateway/jupiter/api/message/DefaultMessage.java
+++ b/src/main/java/io/gravitee/gateway/jupiter/api/message/DefaultMessage.java
@@ -38,8 +38,9 @@ public class DefaultMessage implements Message {
     private String id;
     private Map<String, Object> attributes;
     private Map<String, Object> metadata;
-    private HttpHeaders headers = HttpHeaders.create();
+    private HttpHeaders headers;
     private Buffer content;
+    private boolean error;
 
     public DefaultMessage(final String content) {
         if (content != null) {
@@ -103,6 +104,14 @@ public class DefaultMessage implements Message {
             metadata = Map.of();
         }
         return metadata;
+    }
+
+    @Override
+    public HttpHeaders headers() {
+        if (headers == null) {
+            headers = HttpHeaders.create();
+        }
+        return headers;
     }
 
     public DefaultMessage metadata(Map<String, Object> metadata) {

--- a/src/main/java/io/gravitee/gateway/jupiter/api/message/Message.java
+++ b/src/main/java/io/gravitee/gateway/jupiter/api/message/Message.java
@@ -68,6 +68,8 @@ public interface Message {
 
     String id();
 
+    boolean error();
+
     Map<String, Object> metadata();
 
     HttpHeaders headers();


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/issues/issues/8361

**Description**

Properly manage error on async api reactor.

<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `1.48.0-8361-error-handling-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/gateway/gravitee-gateway-api/1.48.0-8361-error-handling-SNAPSHOT/gravitee-gateway-api-1.48.0-8361-error-handling-SNAPSHOT.zip)
  <!-- Version placeholder end -->
