### PR TITLE
add internal attribute to handle last message

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
 
     <groupId>io.gravitee.gateway</groupId>
     <artifactId>gravitee-gateway-api</artifactId>
-    <version>1.46.2</version>
+    <version>1.46.3-int-att-for-messages-SNAPSHOT</version>
 
     <name>Gravitee.io APIM - Gateway - API</name>
 

--- a/src/main/java/io/gravitee/gateway/jupiter/api/context/InternalContextAttributes.java
+++ b/src/main/java/io/gravitee/gateway/jupiter/api/context/InternalContextAttributes.java
@@ -37,6 +37,11 @@ public final class InternalContextAttributes {
     public static final String ATTR_INTERNAL_LISTENER_TYPE = "listener.type";
 
     /**
+     * Attribute used to store the id of the last message sent to a client.
+     */
+    public static final String ATTR_INTERNAL_LAST_MESSAGE_ID = "last.message.id";
+
+    /**
      * <b>Feature: LIMIT</b> <br/>
      * <i>Type: integer</i> <br/>
      * Attribute used to store the maximum number of messages to retrieve, asked by the client.


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/issues/issues/8307

**Description**
add internal attribute to handle last message sent to a client
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `1.46.3-int-att-for-messages-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/gateway/gravitee-gateway-api/1.46.3-int-att-for-messages-SNAPSHOT/gravitee-gateway-api-1.46.3-int-att-for-messages-SNAPSHOT.zip)
  <!-- Version placeholder end -->
