### PR TITLE
Add ATTR_INTERNAL_SECURITY_TOKEN constant

### DIFF
--- a/src/main/java/io/gravitee/gateway/jupiter/api/context/InternalContextAttributes.java
+++ b/src/main/java/io/gravitee/gateway/jupiter/api/context/InternalContextAttributes.java
@@ -27,6 +27,7 @@ public final class InternalContextAttributes {
 
     public static final String ATTR_INTERNAL_EXECUTION_FAILURE = "execution-failure";
     public static final String ATTR_INTERNAL_FLOW_STAGE = "flow.stage";
+    public static final String ATTR_INTERNAL_SECURITY_TOKEN = "securityChain.securityToken";
     /**
      * Adapted ExecutionContext for V3 compatibility.
      */


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/issues/issues/8498

**Description**

Extracted from [gravitee-io/gravitee-api-management@`1b27371` (#2510)](https://github.com/gravitee-io/gravitee-api-management/pull/2510/commits/1b273719679b0a1da3a540619767eeac6c001222#diff-4d5a2181d283c81b5b089db4714dd97b4608a4f2ba81e4b61ada8358c1c13440R55)

Add ATTR_INTERNAL_SECURITY_TOKEN constant to handle apikey vs keyless plans selection
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `1.44.1-8498-jupiter-apikey-fallback-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/gateway/gravitee-gateway-api/1.44.1-8498-jupiter-apikey-fallback-SNAPSHOT/gravitee-gateway-api-1.44.1-8498-jupiter-apikey-fallback-SNAPSHOT.zip)
  <!-- Version placeholder end -->
