### PR TITLE
feat: handle stop on entrypoint connector

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,13 +29,13 @@
 
     <groupId>io.gravitee.gateway</groupId>
     <artifactId>gravitee-gateway-api</artifactId>
-    <version>1.48.0-develop-SNAPSHOT</version>
+    <version>1.48.0-apim-92-entrypoint-lifecycle-stop-SNAPSHOT</version>
     <name>Gravitee.io APIM - Gateway - API</name>
 
     <properties>
         <gravitee-bom.version>2.5</gravitee-bom.version>
         <gravitee-tracing-api.version>1.0.0</gravitee-tracing-api.version>
-        <gravitee-common.version>1.24.0</gravitee-common.version>
+        <gravitee-common.version>1.28.0</gravitee-common.version>
         <gravitee-policy-api.version>1.11.0</gravitee-policy-api.version>
         <gravitee-reporter-api.version>1.22.0</gravitee-reporter-api.version>
         <gravitee-expression-language.version>1.10.1</gravitee-expression-language.version>

--- a/src/main/java/io/gravitee/gateway/jupiter/api/connector/Connector.java
+++ b/src/main/java/io/gravitee/gateway/jupiter/api/connector/Connector.java
@@ -15,6 +15,7 @@
  */
 package io.gravitee.gateway.jupiter.api.connector;
 
+import io.gravitee.common.component.LifecycleComponent;
 import io.gravitee.gateway.jupiter.api.ApiType;
 import io.gravitee.gateway.jupiter.api.ConnectorMode;
 import java.util.Set;
@@ -25,7 +26,7 @@ import java.util.Set;
  * @author Guillaume LAMIRAND (guillaume.lamirand at graviteesource.com)
  * @author GraviteeSource Team
  */
-public interface Connector {
+public interface Connector extends LifecycleComponent<Connector> {
     /**
      * Returns the id of the connector
      *

--- a/src/main/java/io/gravitee/gateway/jupiter/api/connector/endpoint/async/EndpointAsyncConnector.java
+++ b/src/main/java/io/gravitee/gateway/jupiter/api/connector/endpoint/async/EndpointAsyncConnector.java
@@ -17,6 +17,7 @@ package io.gravitee.gateway.jupiter.api.connector.endpoint.async;
 
 import static io.gravitee.gateway.jupiter.api.context.InternalContextAttributes.ATTR_INTERNAL_ENTRYPOINT_CONNECTOR;
 
+import io.gravitee.common.service.AbstractService;
 import io.gravitee.gateway.jupiter.api.ApiType;
 import io.gravitee.gateway.jupiter.api.ConnectorMode;
 import io.gravitee.gateway.jupiter.api.connector.Connector;
@@ -30,7 +31,7 @@ import java.util.List;
 /**
  * Specialized {@link EndpointConnector} for {@link ApiType#ASYNC}
  */
-public abstract class EndpointAsyncConnector implements EndpointConnector {
+public abstract class EndpointAsyncConnector extends AbstractService<Connector> implements EndpointConnector {
 
     @Override
     public ApiType supportedApi() {


### PR DESCRIPTION
**Issue**

https://graviteecommunity.atlassian.net/browse/APIM-92

**Description**

Implement common way send stop hook to entrypoint connectors.
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `1.48.0-apim-92-entrypoint-lifecycle-stop-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/gateway/gravitee-gateway-api/1.48.0-apim-92-entrypoint-lifecycle-stop-SNAPSHOT/gravitee-gateway-api-1.48.0-apim-92-entrypoint-lifecycle-stop-SNAPSHOT.zip)
  <!-- Version placeholder end -->
