### PR TITLE
APIM-98 add method to easily interrupt body or message flow

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
 
     <groupId>io.gravitee.gateway</groupId>
     <artifactId>gravitee-gateway-api</artifactId>
-    <version>1.48.0-alpha.1</version>
+    <version>1.48.0-apim-98-better-message-error-handling-SNAPSHOT</version>
 
     <name>Gravitee.io APIM - Gateway - API</name>
 

--- a/src/main/java/io/gravitee/gateway/jupiter/api/context/HttpExecutionContext.java
+++ b/src/main/java/io/gravitee/gateway/jupiter/api/context/HttpExecutionContext.java
@@ -15,8 +15,10 @@
  */
 package io.gravitee.gateway.jupiter.api.context;
 
+import io.gravitee.gateway.api.buffer.Buffer;
 import io.gravitee.gateway.jupiter.api.ExecutionFailure;
 import io.reactivex.Completable;
+import io.reactivex.Maybe;
 
 public interface HttpExecutionContext extends GenericExecutionContext {
     String TEMPLATE_ATTRIBUTE_REQUEST = "request";
@@ -38,7 +40,7 @@ public interface HttpExecutionContext extends GenericExecutionContext {
     HttpResponse response();
 
     /**
-     * Interrupted the current execution while indicating that the response can be sent "as is" to the downstream.
+     * Interrupts the current execution while indicating that the response can be sent "as is" to the downstream.
      * This has direct impact on how the remaining execution flow will behave (ex: remaining policies in a policy chain won't be executed).
      */
     Completable interrupt();
@@ -47,4 +49,15 @@ public interface HttpExecutionContext extends GenericExecutionContext {
      * Same as {@link #interrupt()} but with an {@link ExecutionFailure} object that indicates that the execution has failed. The {@link ExecutionFailure} can be processed in order to build a proper response (ex: based on templating, with appropriate accept-encoding, ...).
      */
     Completable interruptWith(final ExecutionFailure failure);
+
+    /**
+     * Interrupts the current execution while indicating that the response can be sent "as is" to the downstream.
+     * This has direct impact on how the remaining execution flow will behave (ex: remaining policies in a policy chain won't be executed).
+     */
+    Maybe<Buffer> interruptBody();
+
+    /**
+     * Same as {@link #interruptBody()} but with an {@link ExecutionFailure} object that indicates that the execution has failed. The {@link ExecutionFailure} can be processed in order to build a proper response (ex: based on templating, with appropriate accept-encoding, ...).
+     */
+    Maybe<Buffer> interruptBodyWith(final ExecutionFailure failure);
 }

--- a/src/main/java/io/gravitee/gateway/jupiter/api/context/MessageExecutionContext.java
+++ b/src/main/java/io/gravitee/gateway/jupiter/api/context/MessageExecutionContext.java
@@ -18,6 +18,7 @@ package io.gravitee.gateway.jupiter.api.context;
 import io.gravitee.gateway.jupiter.api.ExecutionFailure;
 import io.gravitee.gateway.jupiter.api.message.Message;
 import io.reactivex.Flowable;
+import io.reactivex.Maybe;
 
 public interface MessageExecutionContext extends GenericExecutionContext {
     /**
@@ -35,7 +36,7 @@ public interface MessageExecutionContext extends GenericExecutionContext {
     MessageResponse response();
 
     /**
-     * Interrupted the current execution while indicating that the flow of messages can be consumed "as is" to the downstream.
+     * Interrupts the current execution while indicating that the flow of messages can be consumed "as is" to the downstream.
      * This has direct impact on how the remaining execution flow will behave (ex: remaining policies in a policy chain won't be executed).
      */
     Flowable<Message> interruptMessages();
@@ -44,4 +45,14 @@ public interface MessageExecutionContext extends GenericExecutionContext {
      * Same as {@link #interruptMessages()} but with an {@link ExecutionFailure} object that indicates that the execution has failed. The {@link ExecutionFailure} can be processed in order to build a proper response (ex: based on templating, with appropriate accept-encoding, ...).
      */
     Flowable<Message> interruptMessagesWith(final ExecutionFailure failure);
+
+    /**
+     * Same as {@link MessageExecutionContext#interruptMessages} but at message level
+     */
+    Maybe<Message> interruptMessage();
+
+    /**
+     * Same as {@link MessageExecutionContext#interruptMessagesWith(ExecutionFailure)} but at message level
+     */
+    Maybe<Message> interruptMessageWith(final ExecutionFailure failure);
 }


### PR DESCRIPTION
## Issue

https://graviteecommunity.atlassian.net/browse/APIM-98

## Description

Add method to easily interrupt body or message flow

<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `1.48.0-apim-98-better-message-error-handling-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/gateway/gravitee-gateway-api/1.48.0-apim-98-better-message-error-handling-SNAPSHOT/gravitee-gateway-api-1.48.0-apim-98-better-message-error-handling-SNAPSHOT.zip)
  <!-- Version placeholder end -->
