### PR TITLE
feat: add entrypoint subscription configuration

### DIFF
--- a/src/main/java/io/gravitee/gateway/jupiter/api/connector/entrypoint/async/EntrypointConnectorSubscriptionConfiguration.java
+++ b/src/main/java/io/gravitee/gateway/jupiter/api/connector/entrypoint/async/EntrypointConnectorSubscriptionConfiguration.java
@@ -1,0 +1,27 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gateway.jupiter.api.connector.entrypoint.async;
+
+import io.gravitee.gateway.jupiter.api.connector.entrypoint.EntrypointConnector;
+
+/**
+ * Default empty subscription configuration for {@link EntrypointConnector}
+ *
+ * @author Yann TAVERNIER (yann.tavernier at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+public interface EntrypointConnectorSubscriptionConfiguration {
+}


### PR DESCRIPTION
**Issue**

https://graviteecommunity.atlassian.net/browse/APIM-189

**Description**

Add a `EntrypointConnectorSubscriptionConfiguration` to be able to: 
- retrieve the configuration object for a subscription in the connector
- validate a subscription against its connector configuration (for subscription level)

