### PR TITLE
feat: add entrypoint subscription configuration capabilities

### DIFF
--- a/src/main/java/io/gravitee/gateway/jupiter/api/connector/entrypoint/async/EntrypointConnectorSubscriptionConfiguration.java
+++ b/src/main/java/io/gravitee/gateway/jupiter/api/connector/entrypoint/async/EntrypointConnectorSubscriptionConfiguration.java
@@ -1,0 +1,28 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gateway.jupiter.api.connector.entrypoint.async;
+
+import io.gravitee.gateway.jupiter.api.connector.entrypoint.EntrypointConnector;
+
+/**
+ * Default empty subscription configuration for {@link EntrypointConnector}
+ *
+ * @author Yann TAVERNIER (yann.tavernier at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+public interface EntrypointConnectorSubscriptionConfiguration {
+    String entrypointId();
+}


### PR DESCRIPTION
**Issue**

https://graviteecommunity.atlassian.net/browse/APIM-65

<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `2.0.0-apim-65-api-with-webhook-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/gateway/gravitee-gateway-api/2.0.0-apim-65-api-with-webhook-SNAPSHOT/gravitee-gateway-api-2.0.0-apim-65-api-with-webhook-SNAPSHOT.zip)
  <!-- Version placeholder end -->
