### PR TITLE
feat: add deployment context to connector factory

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
 
     <groupId>io.gravitee.gateway</groupId>
     <artifactId>gravitee-gateway-api</artifactId>
-    <version>2.0.0-alpha.3</version>
+    <version>2.0.0-apim-266-http-proxy-connectors-SNAPSHOT</version>
     <name>Gravitee.io APIM - Gateway - API</name>
 
     <properties>

--- a/src/main/java/io/gravitee/gateway/api/ExecutionContext.java
+++ b/src/main/java/io/gravitee/gateway/api/ExecutionContext.java
@@ -48,6 +48,12 @@ public interface ExecutionContext {
     String ATTR_ENVIRONMENT = ATTR_PREFIX + "environment";
     String ATTR_FAILURE_ATTRIBUTE = ATTR_PREFIX + "failure";
 
+    /**
+     * Skip security chain isn't prefixed to avoid breaking code where this constant isn't used.
+     */
+    String ATTR_SECURITY_SKIP = "skip-security-chain";
+    String ATTR_INVOKER_SKIP = "invoker.skip";
+
     Request request();
 
     Response response();

--- a/src/main/java/io/gravitee/gateway/jupiter/api/connector/ConnectorFactory.java
+++ b/src/main/java/io/gravitee/gateway/jupiter/api/connector/ConnectorFactory.java
@@ -17,6 +17,7 @@ package io.gravitee.gateway.jupiter.api.connector;
 
 import io.gravitee.gateway.jupiter.api.ApiType;
 import io.gravitee.gateway.jupiter.api.ConnectorMode;
+import io.gravitee.gateway.jupiter.api.context.DeploymentContext;
 import java.util.Set;
 
 /**
@@ -37,9 +38,12 @@ public interface ConnectorFactory<T extends Connector> {
     Set<ConnectorMode> supportedModes();
 
     /**
-     * Allow creating new connector from the given string configuration
+     * Allow creating new connector from the given string configuration.
      *
-     * @return new connector instance
+     * @param deploymentContext context containing useful deployment entities (api, services, ...).
+     * @param configuration the configuration as json string.
+     *
+     * @return new connector instance.
      */
-    T createConnector(final String configuration);
+    T createConnector(final DeploymentContext deploymentContext, final String configuration);
 }

--- a/src/main/java/io/gravitee/gateway/jupiter/api/connector/endpoint/async/EndpointAsyncConnectorFactory.java
+++ b/src/main/java/io/gravitee/gateway/jupiter/api/connector/endpoint/async/EndpointAsyncConnectorFactory.java
@@ -24,7 +24,7 @@ import java.util.Set;
 /**
  * Specialized factory for {@link EndpointAsyncConnector}
  */
-public interface EndpointAsyncConnectorFactory extends EndpointConnectorFactory<EndpointAsyncConnector> {
+public interface EndpointAsyncConnectorFactory<T extends EndpointAsyncConnector> extends EndpointConnectorFactory<T> {
     @Override
     default ApiType supportedApi() {
         return ApiType.ASYNC;

--- a/src/main/java/io/gravitee/gateway/jupiter/api/connector/endpoint/sync/EndpointSyncConnector.java
+++ b/src/main/java/io/gravitee/gateway/jupiter/api/connector/endpoint/sync/EndpointSyncConnector.java
@@ -15,7 +15,9 @@
  */
 package io.gravitee.gateway.jupiter.api.connector.endpoint.sync;
 
+import io.gravitee.common.service.AbstractService;
 import io.gravitee.gateway.jupiter.api.ApiType;
+import io.gravitee.gateway.jupiter.api.connector.Connector;
 import io.gravitee.gateway.jupiter.api.connector.endpoint.EndpointConnector;
 import io.gravitee.gateway.jupiter.api.qos.Qos;
 import java.util.Set;
@@ -23,7 +25,7 @@ import java.util.Set;
 /**
  * Specialized {@link EndpointConnector} for {@link ApiType#SYNC}
  */
-public abstract class EndpointSyncConnector implements EndpointConnector {
+public abstract class EndpointSyncConnector extends AbstractService<Connector> implements EndpointConnector {
 
     @Override
     public ApiType supportedApi() {

--- a/src/main/java/io/gravitee/gateway/jupiter/api/connector/endpoint/sync/EndpointSyncConnectorFactory.java
+++ b/src/main/java/io/gravitee/gateway/jupiter/api/connector/endpoint/sync/EndpointSyncConnectorFactory.java
@@ -23,7 +23,7 @@ import java.util.Set;
 /**
  * Specialized factory for {@link EndpointSyncConnector}
  */
-public interface EndpointSyncConnectorFactory extends EndpointConnectorFactory<EndpointSyncConnector> {
+public interface EndpointSyncConnectorFactory<T extends EndpointSyncConnector> extends EndpointConnectorFactory<T> {
     @Override
     default Set<ConnectorMode> supportedModes() {
         return Set.of(ConnectorMode.REQUEST_RESPONSE);

--- a/src/main/java/io/gravitee/gateway/jupiter/api/connector/entrypoint/async/EntrypointAsyncConnectorFactory.java
+++ b/src/main/java/io/gravitee/gateway/jupiter/api/connector/entrypoint/async/EntrypointAsyncConnectorFactory.java
@@ -18,13 +18,14 @@ package io.gravitee.gateway.jupiter.api.connector.entrypoint.async;
 import io.gravitee.gateway.jupiter.api.ApiType;
 import io.gravitee.gateway.jupiter.api.ConnectorMode;
 import io.gravitee.gateway.jupiter.api.connector.entrypoint.EntrypointConnectorFactory;
+import io.gravitee.gateway.jupiter.api.context.DeploymentContext;
 import io.gravitee.gateway.jupiter.api.qos.Qos;
 import java.util.Set;
 
 /**
  * Specialized factory for {@link EntrypointAsyncConnector}
  */
-public interface EntrypointAsyncConnectorFactory extends EntrypointConnectorFactory<EntrypointAsyncConnector> {
+public interface EntrypointAsyncConnectorFactory<T extends EntrypointAsyncConnector> extends EntrypointConnectorFactory<T> {
     @Override
     default ApiType supportedApi() {
         return ApiType.ASYNC;
@@ -38,18 +39,22 @@ public interface EntrypointAsyncConnectorFactory extends EntrypointConnectorFact
     Set<Qos> supportedQos();
 
     /**
-     * Allow creating new connector from the given string configuration.
-     *
-     * @return new connector instance
+     * {@inheritDoc}
+     * <p/>
+     * Same as {@link #createConnector(DeploymentContext, Qos, String)} but without Qos.
      */
-    default EntrypointAsyncConnector createConnector(final String configuration) {
-        return createConnector(null, configuration);
+    default T createConnector(final DeploymentContext deploymentContext, final String configuration) {
+        return createConnector(deploymentContext, null, configuration);
     }
 
     /**
-     * Allow creating new connector from the given string configuration
+     * Allow creating new connector from the given string configuration and QoS (Quality Of Service).
      *
-     * @return new connector instance
+     * @param deploymentContext context containing useful deployment entities (api, services, ...).
+     * @param qos the expected quality of service.
+     * @param configuration the configuration as json string.
+     *
+     * @return new connector instance.
      */
-    EntrypointAsyncConnector createConnector(final Qos qos, final String configuration);
+    T createConnector(final DeploymentContext deploymentContext, final Qos qos, final String configuration);
 }

--- a/src/main/java/io/gravitee/gateway/jupiter/api/connector/entrypoint/sync/EntrypointSyncConnector.java
+++ b/src/main/java/io/gravitee/gateway/jupiter/api/connector/entrypoint/sync/EntrypointSyncConnector.java
@@ -15,7 +15,9 @@
  */
 package io.gravitee.gateway.jupiter.api.connector.entrypoint.sync;
 
+import io.gravitee.common.service.AbstractService;
 import io.gravitee.gateway.jupiter.api.ApiType;
+import io.gravitee.gateway.jupiter.api.connector.Connector;
 import io.gravitee.gateway.jupiter.api.connector.entrypoint.EntrypointConnector;
 import io.gravitee.gateway.jupiter.api.qos.Qos;
 import java.util.Set;
@@ -23,7 +25,7 @@ import java.util.Set;
 /**
  * Specialized {@link EntrypointConnector} for {@link ApiType#SYNC}
  */
-public abstract class EntrypointSyncConnector implements EntrypointConnector {
+public abstract class EntrypointSyncConnector extends AbstractService<Connector> implements EntrypointConnector {
 
     @Override
     public ApiType supportedApi() {

--- a/src/main/java/io/gravitee/gateway/jupiter/api/context/ContextAttributes.java
+++ b/src/main/java/io/gravitee/gateway/jupiter/api/context/ContextAttributes.java
@@ -34,7 +34,6 @@ public final class ContextAttributes {
     public static final String ATTR_QUOTA_LIMIT = ATTR_PREFIX + "quota.limit";
     public static final String ATTR_QUOTA_REMAINING = ATTR_PREFIX + "quota.remaining";
     public static final String ATTR_QUOTA_COUNT = ATTR_PREFIX + "quota.count";
-    public static final String ATTR_INVOKER = ATTR_PREFIX + "request.invoker";
     public static final String ATTR_REQUEST_ENDPOINT = ATTR_PREFIX + "request.endpoint";
     public static final String ATTR_REQUEST_METHOD = ATTR_PREFIX + "request.method";
     public static final String ATTR_PLAN = ATTR_PREFIX + "plan";
@@ -44,7 +43,4 @@ public final class ContextAttributes {
     public static final String ATTR_APPLICATION = ATTR_PREFIX + "application";
     public static final String ATTR_RESOLVED_PATH = ATTR_PREFIX + "resolved-path";
     public static final String ATTR_CONTEXT_PATH = ATTR_PREFIX + "context-path";
-
-    // For jupiter v3 compatibility, should be moved to internal attributes at term.
-    public static final String ATTR_SKIP_SECURITY_CHAIN = "skip-security-chain";
 }

--- a/src/main/java/io/gravitee/gateway/jupiter/api/context/DeploymentContext.java
+++ b/src/main/java/io/gravitee/gateway/jupiter/api/context/DeploymentContext.java
@@ -1,0 +1,44 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gateway.jupiter.api.context;
+
+import io.gravitee.el.TemplateEngine;
+
+/**
+ * The {@link DeploymentContext} allows to access useful information at deployment time.
+ * It is the responsibility of the implementation to give access to the component of its choice (ex: api definition, services components, ...).
+ *
+ * @author Jeoffrey HAEYAERT (jeoffrey.haeyaert at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+public interface DeploymentContext {
+    /**
+     * Returns the component corresponding to the specified <code>componentClass</code>.
+     *
+     * @param componentClass the {@link Class} of the expected component to retrieve.
+     * @param <T> the expected instance type.
+     *
+     * @return the component or <code>null</code> if no component found.
+     */
+    <T> T getComponent(Class<T> componentClass);
+
+    /**
+     * Get the {@link TemplateEngine} that can be used to evaluate EL expressions.
+     *
+     * @return the El {@link TemplateEngine}.
+     */
+    TemplateEngine getTemplateEngine();
+}

--- a/src/main/java/io/gravitee/gateway/jupiter/api/context/InternalContextAttributes.java
+++ b/src/main/java/io/gravitee/gateway/jupiter/api/context/InternalContextAttributes.java
@@ -30,11 +30,14 @@ public final class InternalContextAttributes {
      */
     public static final String ATTR_INTERNAL_ENTRYPOINT_CONNECTOR = "entrypointConnector";
     public static final String ATTR_INTERNAL_INVOKER = "invoker";
+    public static final String ATTR_INTERNAL_INVOKER_SKIP = "invoker.skip";
     public static final String ATTR_INTERNAL_EXECUTION_FAILURE = "executionFailure";
     public static final String ATTR_INTERNAL_FLOW_STAGE = "flow.stage";
     public static final String ATTR_INTERNAL_SUBSCRIPTION = "subscription";
     public static final String ATTR_INTERNAL_SUBSCRIPTION_TYPE = "subscription_type";
     public static final String ATTR_INTERNAL_SECURITY_TOKEN = "securityChain.securityToken";
+    public static final String ATTR_INTERNAL_SECURITY_SKIP = "securityChain.skip";
+
     /**
      * Adapted ExecutionContext for V3 compatibility.
      */


### PR DESCRIPTION
**Issue**

https://graviteecommunity.atlassian.net/browse/APIM-266

**Description**

Add a deployment context object to pass to connector factory in order to get access to useful component such as api, services, ...
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `2.0.0-apim-266-http-proxy-connectors-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/gateway/gravitee-gateway-api/2.0.0-apim-266-http-proxy-connectors-SNAPSHOT/gravitee-gateway-api-2.0.0-apim-266-http-proxy-connectors-SNAPSHOT.zip)
  <!-- Version placeholder end -->
