### PR TITLE
fix: distinguish host from  original host on request

### DIFF
--- a/src/main/java/io/gravitee/gateway/jupiter/api/context/GenericRequest.java
+++ b/src/main/java/io/gravitee/gateway/jupiter/api/context/GenericRequest.java
@@ -46,6 +46,14 @@ public interface GenericRequest {
     String host();
 
     /**
+     * Allows to retrieve the request original host.
+     * Unlike the {@link #host()}, it remains the same and can't be altered during the request processing.
+     *
+     * @return the original reuqest host.
+     */
+    String originalHost();
+
+    /**
      * @return the part of this request's URL from the protocol name up to the query string in the first line
      * of the HTTP request.
      */


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/APIM-349

**Description**

Add an `originalHost()` to distinguish from `host()` which is allowed to be altered during request processing.
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `2.0.0-apim-349-http-host-propagation-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/gateway/gravitee-gateway-api/2.0.0-apim-349-http-host-propagation-SNAPSHOT/gravitee-gateway-api-2.0.0-apim-349-http-host-propagation-SNAPSHOT.zip)
  <!-- Version placeholder end -->
