### PR TITLE
feat: introduce dlq service concept

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
 
     <groupId>io.gravitee.gateway</groupId>
     <artifactId>gravitee-gateway-api</artifactId>
-    <version>2.0.0</version>
+    <version>2.1.0-apim-339-dead-letter-queue-SNAPSHOT</version>
     <name>Gravitee.io APIM - Gateway - API</name>
 
     <properties>

--- a/src/main/java/io/gravitee/gateway/jupiter/api/connector/endpoint/async/EndpointAsyncConnector.java
+++ b/src/main/java/io/gravitee/gateway/jupiter/api/connector/endpoint/async/EndpointAsyncConnector.java
@@ -72,7 +72,7 @@ public abstract class EndpointAsyncConnector extends AbstractService<Connector> 
         });
     }
 
-    protected abstract Completable subscribe(final ExecutionContext ctx);
+    public abstract Completable subscribe(final ExecutionContext ctx);
 
-    protected abstract Completable publish(final ExecutionContext ctx);
+    public abstract Completable publish(final ExecutionContext ctx);
 }

--- a/src/main/java/io/gravitee/gateway/jupiter/api/message/DefaultMessage.java
+++ b/src/main/java/io/gravitee/gateway/jupiter/api/message/DefaultMessage.java
@@ -133,13 +133,13 @@ public class DefaultMessage implements Message {
     }
 
     @Override
-    public Message content(Buffer content) {
+    public DefaultMessage content(Buffer content) {
         this.content = content;
         return this;
     }
 
     @Override
-    public Message content(String content) {
+    public DefaultMessage content(String content) {
         if (content != null) {
             this.content(Buffer.buffer(content));
         } else {

--- a/src/main/java/io/gravitee/gateway/jupiter/api/message/Message.java
+++ b/src/main/java/io/gravitee/gateway/jupiter/api/message/Message.java
@@ -124,6 +124,13 @@ public interface Message {
     boolean error();
 
     /**
+     * Flag indicating the message is in error.
+     * An error can occur during the processing. In that case, it is flagged in <code>error</code> to indicate that a special behavior may have to be applied for it.
+     *
+     */
+    Message error(boolean error);
+
+    /**
      * Get the metadata of the message. Metadata are read-only. They usually come from the source that emits the message and can't be changed.
      *
      * @return the metadata of the message or an empty map if the message doesn't have any metadata.

--- a/src/main/java/io/gravitee/gateway/jupiter/api/service/dlq/DlqService.java
+++ b/src/main/java/io/gravitee/gateway/jupiter/api/service/dlq/DlqService.java
@@ -1,0 +1,39 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gateway.jupiter.api.service.dlq;
+
+import io.gravitee.gateway.jupiter.api.message.Message;
+import io.reactivex.rxjava3.core.Flowable;
+import java.util.concurrent.Flow;
+
+/**
+ * Allows applying behavior on a flow of messages in order to filter messages in error and send them ot a Dead Letter Queue.
+ *
+ * @author Jeoffrey HAEYAERT (jeoffrey.haeyaert at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+public interface DlqService {
+    /**
+     * Set up the dead letter queue mechanism on the incoming flow of messages.
+     * It is the responsibility of the implementation to filter incoming messages and send only the appropriate subset of messages to the DLQ
+     * (ex: message in error, message matching a particular condition, ..).
+     *
+     * @param messages the incoming flow of messages.
+     *
+     * @return the original flow of messages, so it can be chained easily.
+     */
+    Flowable<Message> apply(Flowable<Message> messages);
+}

--- a/src/main/java/io/gravitee/gateway/jupiter/api/service/dlq/DlqServiceFactory.java
+++ b/src/main/java/io/gravitee/gateway/jupiter/api/service/dlq/DlqServiceFactory.java
@@ -1,0 +1,35 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gateway.jupiter.api.service.dlq;
+
+import io.gravitee.gateway.jupiter.api.connector.entrypoint.EntrypointConnector;
+
+/**
+ * Factory allowing to instantiate a {@link DlqService} for the specified {@link EntrypointConnector}.
+ *
+ * @author Jeoffrey HAEYAERT (jeoffrey.haeyaert at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+public interface DlqServiceFactory {
+    /**
+     * Create and return a {@link DlqService} that can be used for the specified connector.
+     * In any cases, it always returns a {@link DlqService} that can be safely used without checking for nullability..
+     *
+     * @param connector the entrypoint connector for which create a {@link DlqService}.
+     * @return the created {@link DlqService}.
+     */
+    DlqService create(final EntrypointConnector connector);
+}


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/APIM-339

**Description**

This introduce the `DlqService` concept allowing to implement dead letter queue on entrypoint connectors.
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `2.1.0-apim-339-dead-letter-queue-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/gateway/gravitee-gateway-api/2.1.0-apim-339-dead-letter-queue-SNAPSHOT/gravitee-gateway-api-2.1.0-apim-339-dead-letter-queue-SNAPSHOT.zip)
  <!-- Version placeholder end -->
