### PR TITLE
feat: add exception dedicated to message processing failures

### DIFF
--- a/src/main/java/io/gravitee/gateway/jupiter/api/exception/MessageProcessingException.java
+++ b/src/main/java/io/gravitee/gateway/jupiter/api/exception/MessageProcessingException.java
@@ -1,0 +1,23 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gateway.jupiter.api.exception;
+
+public class MessageProcessingException extends Exception {
+
+    public MessageProcessingException(String message) {
+        super(message);
+    }
+}


### PR DESCRIPTION
https://gravitee.atlassian.net/browse/APIM-64
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `2.1.0-apim64-eeSecureWebhookEntrypoint-onDlq-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/gateway/gravitee-gateway-api/2.1.0-apim64-eeSecureWebhookEntrypoint-onDlq-SNAPSHOT/gravitee-gateway-api-2.1.0-apim64-eeSecureWebhookEntrypoint-onDlq-SNAPSHOT.zip)
  <!-- Version placeholder end -->
