### PR TITLE
feat: add FAILURE consumer status on Subscription

### DIFF
--- a/src/main/java/io/gravitee/gateway/api/service/Subscription.java
+++ b/src/main/java/io/gravitee/gateway/api/service/Subscription.java
@@ -66,5 +66,6 @@ public class Subscription {
     public enum ConsumerStatus {
         STOPPED,
         STARTED,
+        FAILURE,
     }
 }

--- a/src/main/java/io/gravitee/gateway/api/service/SubscriptionService.java
+++ b/src/main/java/io/gravitee/gateway/api/service/SubscriptionService.java
@@ -16,6 +16,7 @@
 package io.gravitee.gateway.api.service;
 
 import io.gravitee.gateway.jupiter.api.policy.SecurityToken;
+import java.util.List;
 import java.util.Optional;
 
 /**
@@ -57,4 +58,18 @@ public interface SubscriptionService {
      * @return Found subscription
      */
     Optional<Subscription> getByApiAndSecurityToken(String api, SecurityToken securityToken, String plan);
+
+    /**
+     * Save the subscription if it is a {@link Subscription.Type#STANDARD} as in {@link SubscriptionService#save(Subscription)}
+     * Dispatch the subscription directly if its type is {@link Subscription.Type#SUBSCRIPTION}
+     * @param subscription to save or dispatch
+     */
+    void saveOrDispatch(Subscription subscription);
+
+    /**
+     * Dispatch the subscription of type {@link Subscription.Type#SUBSCRIPTION} that have previously been saved thanks to {@link SubscriptionService#save(Subscription)}
+     * It allows to trigger the dispatch of subscriptions before an API is effectively deployed.
+     * @param apis for which subscription have to be dispatched
+     */
+    void dispatchFor(List<String> apis);
 }

--- a/src/main/java/io/gravitee/gateway/jupiter/api/context/GenericResponse.java
+++ b/src/main/java/io/gravitee/gateway/jupiter/api/context/GenericResponse.java
@@ -43,4 +43,48 @@ public interface GenericResponse {
      * @return <code>true</code> if the response has been fully pushed to the client, <code>false</code> else.
      */
     boolean ended();
+
+    /**
+     * Indicates if response has status in 100-199 range.
+     * @return true if status is 1xx
+     */
+    default boolean isStatus1xx() {
+        return hasHundredsDigit(status(), 1);
+    }
+
+    /**
+     * Indicates if response has status in 200-299 range.
+     * @return true if status is 2xx
+     */
+    default boolean isStatus2xx() {
+        return hasHundredsDigit(status(), 2);
+    }
+
+    /**
+     * Indicates if response has status in 300-399 range.
+     * @return true if status is 3xx
+     */
+    default boolean isStatus3xx() {
+        return hasHundredsDigit(status(), 3);
+    }
+
+    /**
+     * Indicates if response has status in 400-499 range.
+     * @return true if status is 4xx
+     */
+    default boolean isStatus4xx() {
+        return hasHundredsDigit(status(), 4);
+    }
+
+    /**
+     * Indicates if response has status in 500-599 range.
+     * @return true if status is 5xx
+     */
+    default boolean isStatus5xx() {
+        return hasHundredsDigit(status(), 5);
+    }
+
+    private boolean hasHundredsDigit(int numberToTest, int hundredsDigit) {
+        return numberToTest / 100 == hundredsDigit;
+    }
 }

--- a/src/test/java/io/gravitee/gateway/jupiter/api/context/GenericResponseTest.java
+++ b/src/test/java/io/gravitee/gateway/jupiter/api/context/GenericResponseTest.java
@@ -1,0 +1,108 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gateway.jupiter.api.context;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.gravitee.gateway.api.http.HttpHeaders;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+/**
+ * @author Yann TAVERNIER (yann.tavernier at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+class GenericResponseTest {
+
+    @ParameterizedTest
+    @ValueSource(ints = { 100, 101, 103, 199 })
+    void shouldBeStatus1xxResponse(int status) {
+        final DummyGenericResponse cut = new DummyGenericResponse(status);
+        assertThat(cut.isStatus1xx()).isTrue();
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = { 200, 201, 203, 299 })
+    void shouldBeStatus2xxResponse(int status) {
+        final DummyGenericResponse cut = new DummyGenericResponse(status);
+        assertThat(cut.isStatus2xx()).isTrue();
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = { 300, 301, 303, 399 })
+    void shouldBeStatus3xxResponse(int status) {
+        final DummyGenericResponse cut = new DummyGenericResponse(status);
+        assertThat(cut.isStatus3xx()).isTrue();
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = { 400, 401, 403, 499 })
+    void shouldBeStatus4xxResponse(int status) {
+        final DummyGenericResponse cut = new DummyGenericResponse(status);
+        assertThat(cut.isStatus4xx()).isTrue();
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = { 500, 501, 503, 599 })
+    void shouldBeStatus5xxResponse(int status) {
+        final DummyGenericResponse cut = new DummyGenericResponse(status);
+        assertThat(cut.isStatus5xx()).isTrue();
+    }
+
+    private static class DummyGenericResponse implements GenericResponse {
+
+        private final int status;
+
+        private DummyGenericResponse(int status) {
+            this.status = status;
+        }
+
+        @Override
+        public GenericResponse status(int statusCode) {
+            return this;
+        }
+
+        @Override
+        public int status() {
+            return status;
+        }
+
+        @Override
+        public String reason() {
+            return null;
+        }
+
+        @Override
+        public GenericResponse reason(String message) {
+            return null;
+        }
+
+        @Override
+        public HttpHeaders headers() {
+            return null;
+        }
+
+        @Override
+        public HttpHeaders trailers() {
+            return null;
+        }
+
+        @Override
+        public boolean ended() {
+            return false;
+        }
+    }
+}


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/APIM-373
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `2.1.0-apim-373-subscription-error-management-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/gateway/gravitee-gateway-api/2.1.0-apim-373-subscription-error-management-SNAPSHOT/gravitee-gateway-api-2.1.0-apim-373-subscription-error-management-SNAPSHOT.zip)
  <!-- Version placeholder end -->
