### PR TITLE
feat: add http method setter in HttpRequest

### DIFF
--- a/src/main/java/io/gravitee/gateway/jupiter/api/context/HttpRequest.java
+++ b/src/main/java/io/gravitee/gateway/jupiter/api/context/HttpRequest.java
@@ -15,6 +15,7 @@
  */
 package io.gravitee.gateway.jupiter.api.context;
 
+import io.gravitee.common.http.HttpMethod;
 import io.gravitee.gateway.api.buffer.Buffer;
 import io.gravitee.gateway.jupiter.api.ws.WebSocket;
 import io.reactivex.rxjava3.core.Completable;
@@ -196,4 +197,6 @@ public interface HttpRequest extends GenericRequest {
      * @param length The value of the `Content-Length` header
      */
     void contentLength(long length);
+
+    void method(HttpMethod method);
 }


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/APIM-466

**Description**

Add the possibility to set the http method on a HttpRequest
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `2.1.0-apim-466-support-http-method-verride-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/gateway/gravitee-gateway-api/2.1.0-apim-466-support-http-method-verride-SNAPSHOT/gravitee-gateway-api-2.1.0-apim-466-support-http-method-verride-SNAPSHOT.zip)
  <!-- Version placeholder end -->
