### PR TITLE
chore: remove maven-javadoc-plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -144,16 +144,6 @@
     </dependencies>
     <build>
       <plugins>
-        <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-javadoc-plugin</artifactId>
-            <version>2.8</version>
-            <configuration>
-                <additionalJOption>-Xdoclint:none</additionalJOption>
-                <source>8</source>
-            </configuration>
-        </plugin>
-
           <plugin>
               <groupId>com.hubspot.maven.plugins</groupId>
               <artifactId>prettier-maven-plugin</artifactId>


### PR DESCRIPTION

<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `2.1.0-remove-gw-api-javadoc-plugin-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/gateway/gravitee-gateway-api/2.1.0-remove-gw-api-javadoc-plugin-SNAPSHOT/gravitee-gateway-api-2.1.0-remove-gw-api-javadoc-plugin-SNAPSHOT.zip)
  <!-- Version placeholder end -->
