### PR TITLE
feat: add supportedListenerType to EntrypointConnectorFactory interface

### DIFF
--- a/src/main/java/io/gravitee/gateway/jupiter/api/connector/entrypoint/EntrypointConnectorFactory.java
+++ b/src/main/java/io/gravitee/gateway/jupiter/api/connector/entrypoint/EntrypointConnectorFactory.java
@@ -15,9 +15,12 @@
  */
 package io.gravitee.gateway.jupiter.api.connector.entrypoint;
 
+import io.gravitee.gateway.jupiter.api.ListenerType;
 import io.gravitee.gateway.jupiter.api.connector.ConnectorFactory;
 
 /**
  * Specialized factory for {@link EntrypointConnector}
  */
-public interface EntrypointConnectorFactory<T extends EntrypointConnector> extends ConnectorFactory<T> {}
+public interface EntrypointConnectorFactory<T extends EntrypointConnector> extends ConnectorFactory<T> {
+    ListenerType supportedListenerType();
+}


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/APIM-574

**Description**

Add supportedListenerType to EntrypointConnectorFactory interface to be able to return ListenerType with ConnectorListItem on v4/entrypoints GET  

PR: 
- https://github.com/gravitee-io/gravitee-api-management/pull/2968

**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `2.1.0-APIM-574-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/gateway/gravitee-gateway-api/2.1.0-APIM-574-SNAPSHOT/gravitee-gateway-api-2.1.0-APIM-574-SNAPSHOT.zip)
  <!-- Version placeholder end -->
