### PR TITLE
feat: add new internal attribute to store apireactor

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
 
     <groupId>io.gravitee.gateway</groupId>
     <artifactId>gravitee-gateway-api</artifactId>
-    <version>2.1.0-alpha.9</version>
+    <version>2.1.0-apim-490-add-definition-version-attribute-SNAPSHOT</version>
     <name>Gravitee.io APIM - Gateway - API</name>
 
     <properties>
@@ -37,7 +37,7 @@
         <gravitee-tracing-api.version>1.0.0</gravitee-tracing-api.version>
         <gravitee-common.version>2.1.0-alpha.3</gravitee-common.version>
         <gravitee-policy-api.version>1.11.0</gravitee-policy-api.version>
-        <gravitee-reporter-api.version>1.25.0-alpha.1</gravitee-reporter-api.version>
+        <gravitee-reporter-api.version>1.25.0-alpha.2</gravitee-reporter-api.version>
         <gravitee-expression-language.version>2.0.0</gravitee-expression-language.version>
         <gravitee-apim-gateway-buffer.version>3.19.0</gravitee-apim-gateway-buffer.version>
     </properties>

--- a/src/main/java/io/gravitee/gateway/jupiter/api/ApiType.java
+++ b/src/main/java/io/gravitee/gateway/jupiter/api/ApiType.java
@@ -32,7 +32,6 @@ public enum ApiType {
 
     private static final Map<String, ApiType> LABELS_MAP = Map.of(SYNC.label, SYNC, ASYNC.label, ASYNC);
 
-
     @JsonValue
     private final String label;
 

--- a/src/main/java/io/gravitee/gateway/jupiter/api/context/InternalContextAttributes.java
+++ b/src/main/java/io/gravitee/gateway/jupiter/api/context/InternalContextAttributes.java
@@ -25,6 +25,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public final class InternalContextAttributes {
 
+    public static final String ATTR_INTERNAL_REACTABLE_API = "reactableApi";
     /**
      * Attribute used to store a reference to the {@link io.gravitee.gateway.jupiter.api.connector.entrypoint.EntrypointConnector}
      */


### PR DESCRIPTION
**Issue**

[APIM-490](https://gravitee.atlassian.net/browse/APIM-490)
**Description**

Add new attribute in order to store API reactor in the internal attribute.

**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->


[APIM-490]: https://gravitee.atlassian.net/browse/APIM-490?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `2.1.0-apim-490-add-definition-version-attribute-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/gateway/gravitee-gateway-api/2.1.0-apim-490-add-definition-version-attribute-SNAPSHOT/gravitee-gateway-api-2.1.0-apim-490-add-definition-version-attribute-SNAPSHOT.zip)
  <!-- Version placeholder end -->
