### PR TITLE
fix: add `active` field

### DIFF
--- a/src/main/java/io/gravitee/gateway/api/service/ApiKey.java
+++ b/src/main/java/io/gravitee/gateway/api/service/ApiKey.java
@@ -37,6 +37,8 @@ public class ApiKey {
 
     private boolean paused;
 
+    private boolean active;
+
     public String getId() {
         return id;
     }
@@ -83,6 +85,14 @@ public class ApiKey {
 
     public void setPaused(boolean paused) {
         this.paused = paused;
+    }
+
+    public boolean isActive() {
+        return active;
+    }
+
+    public void setActive(boolean active) {
+        this.active = active;
     }
 
     public String getApi() {


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/issues/issues/8846

**Description**

Add `active` field to determine is the ApiKey is active or not. Useful for ApiKey refresher in the gateway.
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `1.44.2-8846-API-Subscription-not-working-after-closing-and-re-creating-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/gateway/gravitee-gateway-api/1.44.2-8846-API-Subscription-not-working-after-closing-and-re-creating-SNAPSHOT/gravitee-gateway-api-1.44.2-8846-API-Subscription-not-working-after-closing-and-re-creating-SNAPSHOT.zip)
  <!-- Version placeholder end -->
