### PR TITLE
fix: revert change on api type

### DIFF
--- a/src/main/java/io/gravitee/gateway/jupiter/api/ApiType.java
+++ b/src/main/java/io/gravitee/gateway/jupiter/api/ApiType.java
@@ -27,15 +27,11 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 @Getter
 public enum ApiType {
-    REQUEST_RESPONSE("request-response"),
-    EVENT_NATIVE("event-native");
+    SYNC("sync"),
+    ASYNC("async");
 
-    private static final Map<String, ApiType> LABELS_MAP = Map.of(
-        REQUEST_RESPONSE.label,
-        REQUEST_RESPONSE,
-        EVENT_NATIVE.label,
-        EVENT_NATIVE
-    );
+    private static final Map<String, ApiType> LABELS_MAP = Map.of(SYNC.label, SYNC, ASYNC.label, ASYNC);
+
 
     @JsonValue
     private final String label;

--- a/src/main/java/io/gravitee/gateway/jupiter/api/connector/endpoint/async/EndpointAsyncConnector.java
+++ b/src/main/java/io/gravitee/gateway/jupiter/api/connector/endpoint/async/EndpointAsyncConnector.java
@@ -32,13 +32,13 @@ import java.util.List;
 import java.util.Set;
 
 /**
- * Specialized {@link EndpointConnector} for {@link ApiType#EVENT_NATIVE}
+ * Specialized {@link EndpointConnector} for {@link ApiType#ASYNC}
  */
 public abstract class EndpointAsyncConnector extends AbstractService<Connector> implements EndpointConnector {
 
     @Override
     public ApiType supportedApi() {
-        return ApiType.EVENT_NATIVE;
+        return ApiType.ASYNC;
     }
 
     /**

--- a/src/main/java/io/gravitee/gateway/jupiter/api/connector/endpoint/async/EndpointAsyncConnectorFactory.java
+++ b/src/main/java/io/gravitee/gateway/jupiter/api/connector/endpoint/async/EndpointAsyncConnectorFactory.java
@@ -27,7 +27,7 @@ import java.util.Set;
 public interface EndpointAsyncConnectorFactory<T extends EndpointAsyncConnector> extends EndpointConnectorFactory<T> {
     @Override
     default ApiType supportedApi() {
-        return ApiType.EVENT_NATIVE;
+        return ApiType.ASYNC;
     }
 
     /**

--- a/src/main/java/io/gravitee/gateway/jupiter/api/connector/endpoint/sync/EndpointSyncConnector.java
+++ b/src/main/java/io/gravitee/gateway/jupiter/api/connector/endpoint/sync/EndpointSyncConnector.java
@@ -21,12 +21,12 @@ import io.gravitee.gateway.jupiter.api.connector.Connector;
 import io.gravitee.gateway.jupiter.api.connector.endpoint.EndpointConnector;
 
 /**
- * Specialized {@link EndpointConnector} for {@link ApiType#REQUEST_RESPONSE}
+ * Specialized {@link EndpointConnector} for {@link ApiType#SYNC}
  */
 public abstract class EndpointSyncConnector extends AbstractService<Connector> implements EndpointConnector {
 
     @Override
     public ApiType supportedApi() {
-        return ApiType.REQUEST_RESPONSE;
+        return ApiType.SYNC;
     }
 }

--- a/src/main/java/io/gravitee/gateway/jupiter/api/connector/endpoint/sync/EndpointSyncConnectorFactory.java
+++ b/src/main/java/io/gravitee/gateway/jupiter/api/connector/endpoint/sync/EndpointSyncConnectorFactory.java
@@ -31,6 +31,6 @@ public interface EndpointSyncConnectorFactory<T extends EndpointSyncConnector> e
 
     @Override
     default ApiType supportedApi() {
-        return ApiType.REQUEST_RESPONSE;
+        return ApiType.SYNC;
     }
 }

--- a/src/main/java/io/gravitee/gateway/jupiter/api/connector/entrypoint/async/EntrypointAsyncConnector.java
+++ b/src/main/java/io/gravitee/gateway/jupiter/api/connector/entrypoint/async/EntrypointAsyncConnector.java
@@ -28,7 +28,7 @@ import io.reactivex.rxjava3.core.FlowableTransformer;
 import io.reactivex.rxjava3.processors.BehaviorProcessor;
 
 /**
- * Specialized {@link EntrypointConnector} for {@link ApiType#EVENT_NATIVE}
+ * Specialized {@link EntrypointConnector} for {@link ApiType#ASYNC}
  */
 public abstract class EntrypointAsyncConnector extends AbstractService<Connector> implements EntrypointConnector {
 
@@ -39,7 +39,7 @@ public abstract class EntrypointAsyncConnector extends AbstractService<Connector
 
     @Override
     public ApiType supportedApi() {
-        return ApiType.EVENT_NATIVE;
+        return ApiType.ASYNC;
     }
 
     /**

--- a/src/main/java/io/gravitee/gateway/jupiter/api/connector/entrypoint/async/EntrypointAsyncConnectorFactory.java
+++ b/src/main/java/io/gravitee/gateway/jupiter/api/connector/entrypoint/async/EntrypointAsyncConnectorFactory.java
@@ -28,7 +28,7 @@ import java.util.Set;
 public interface EntrypointAsyncConnectorFactory<T extends EntrypointAsyncConnector> extends EntrypointConnectorFactory<T> {
     @Override
     default ApiType supportedApi() {
-        return ApiType.EVENT_NATIVE;
+        return ApiType.ASYNC;
     }
 
     /**

--- a/src/main/java/io/gravitee/gateway/jupiter/api/connector/entrypoint/sync/EntrypointSyncConnector.java
+++ b/src/main/java/io/gravitee/gateway/jupiter/api/connector/entrypoint/sync/EntrypointSyncConnector.java
@@ -21,12 +21,12 @@ import io.gravitee.gateway.jupiter.api.connector.Connector;
 import io.gravitee.gateway.jupiter.api.connector.entrypoint.EntrypointConnector;
 
 /**
- * Specialized {@link EntrypointConnector} for {@link ApiType#REQUEST_RESPONSE}
+ * Specialized {@link EntrypointConnector} for {@link ApiType#SYNC}
  */
 public abstract class EntrypointSyncConnector extends AbstractService<Connector> implements EntrypointConnector {
 
     @Override
     public ApiType supportedApi() {
-        return ApiType.REQUEST_RESPONSE;
+        return ApiType.SYNC;
     }
 }

--- a/src/main/java/io/gravitee/gateway/jupiter/api/connector/entrypoint/sync/EntrypointSyncConnectorFactory.java
+++ b/src/main/java/io/gravitee/gateway/jupiter/api/connector/entrypoint/sync/EntrypointSyncConnectorFactory.java
@@ -31,6 +31,6 @@ public interface EntrypointSyncConnectorFactory extends EntrypointConnectorFacto
 
     @Override
     default ApiType supportedApi() {
-        return ApiType.REQUEST_RESPONSE;
+        return ApiType.SYNC;
     }
 }


### PR DESCRIPTION
**Description**

Reverting the change on api type in order to properly rename in the future the type, interface in once.
