### PR TITLE
Bump reporter api version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -37,7 +37,7 @@
         <gravitee-tracing-api.version>1.0.0</gravitee-tracing-api.version>
         <gravitee-common.version>2.1.0-alpha.3</gravitee-common.version>
         <gravitee-policy-api.version>1.11.0</gravitee-policy-api.version>
-        <gravitee-reporter-api.version>1.25.0-alpha.2</gravitee-reporter-api.version>
+        <gravitee-reporter-api.version>1.25.0-alpha.4</gravitee-reporter-api.version>
         <gravitee-expression-language.version>2.0.0</gravitee-expression-language.version>
         <gravitee-apim-gateway-buffer.version>3.19.0</gravitee-apim-gateway-buffer.version>
     </properties>


### PR DESCRIPTION
**Description**

Bump reporter api version to use latest metrics.
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `2.1.0-bump-reporter-api-version-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/gateway/gravitee-gateway-api/2.1.0-bump-reporter-api-version-SNAPSHOT/gravitee-gateway-api-2.1.0-bump-reporter-api-version-SNAPSHOT.zip)
  <!-- Version placeholder end -->
