### PR TITLE
Merge 1.44.x into 2.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -151,6 +151,13 @@
 
 * add ATTR_INTERNAL_SECURITY_TOKEN constant to handle apikey vs keyless plan selection ([7415451](https://github.com/gravitee-io/gravitee-gateway-api/commit/74154511e5ede072f4d21b83870a307014878e06))
 
+## [1.44.2](https://github.com/gravitee-io/gravitee-gateway-api/compare/1.44.1...1.44.2) (2023-01-30)
+
+
+### Bug Fixes
+
+* add `active` field ([12799a3](https://github.com/gravitee-io/gravitee-gateway-api/commit/12799a3e06af073f3d9fbba0f92110eeaf00a09e))
+
 ## [1.44.1](https://github.com/gravitee-io/gravitee-gateway-api/compare/1.44.0...1.44.1) (2022-09-28)
 
 

--- a/src/main/java/io/gravitee/gateway/api/service/ApiKey.java
+++ b/src/main/java/io/gravitee/gateway/api/service/ApiKey.java
@@ -37,6 +37,8 @@ public class ApiKey {
 
     private boolean paused;
 
+    private boolean active;
+
     public String getId() {
         return id;
     }
@@ -83,6 +85,14 @@ public class ApiKey {
 
     public void setPaused(boolean paused) {
         this.paused = paused;
+    }
+
+    public boolean isActive() {
+        return active;
+    }
+
+    public void setActive(boolean active) {
+        this.active = active;
     }
 
     public String getApi() {


### PR DESCRIPTION
**Issue**
n/a

**Description**

Merge 1.44.x into master (2.0.0) to be able to merge APIM 3.19.x into 3.20.x 

Some fix in apim 3.19.x need this change. And 3.20.x use 2.0.0 or gateway API 


**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `2.0.1-merge-1-44-x-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/gateway/gravitee-gateway-api/2.0.1-merge-1-44-x-SNAPSHOT/gravitee-gateway-api-2.0.1-merge-1-44-x-SNAPSHOT.zip)
  <!-- Version placeholder end -->
