### PR TITLE
feat: introduce api service concept

### DIFF
--- a/src/main/java/io/gravitee/gateway/jupiter/api/apiservice/ApiService.java
+++ b/src/main/java/io/gravitee/gateway/jupiter/api/apiservice/ApiService.java
@@ -1,0 +1,32 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gateway.jupiter.api.apiservice;
+
+import io.reactivex.rxjava3.core.Completable;
+
+/**
+ * @author Jeoffrey HAEYAERT (jeoffrey.haeyaert at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+public interface ApiService {
+    String id();
+
+    String kind();
+
+    Completable start();
+
+    Completable stop();
+}

--- a/src/main/java/io/gravitee/gateway/jupiter/api/apiservice/ApiServiceConfiguration.java
+++ b/src/main/java/io/gravitee/gateway/jupiter/api/apiservice/ApiServiceConfiguration.java
@@ -1,0 +1,22 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gateway.jupiter.api.apiservice;
+
+/**
+ * @author Jeoffrey HAEYAERT (jeoffrey.haeyaert at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+public interface ApiServiceConfiguration {}

--- a/src/main/java/io/gravitee/gateway/jupiter/api/apiservice/ApiServiceFactory.java
+++ b/src/main/java/io/gravitee/gateway/jupiter/api/apiservice/ApiServiceFactory.java
@@ -1,0 +1,32 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gateway.jupiter.api.apiservice;
+
+import io.gravitee.gateway.jupiter.api.context.DeploymentContext;
+
+/**
+ * @author Jeoffrey HAEYAERT (jeoffrey.haeyaert at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+public interface ApiServiceFactory<T extends ApiService> {
+    /**
+     * Allow creating new api service from the given string configuration.
+     *
+     * @param deploymentContext the deployment context containing useful information to create the service.
+     * @return the newly created api service.
+     */
+    T createService(final DeploymentContext deploymentContext);
+}

--- a/src/main/java/io/gravitee/gateway/jupiter/api/context/ContextAttributes.java
+++ b/src/main/java/io/gravitee/gateway/jupiter/api/context/ContextAttributes.java
@@ -35,6 +35,7 @@ public final class ContextAttributes {
     public static final String ATTR_QUOTA_REMAINING = ATTR_PREFIX + "quota.remaining";
     public static final String ATTR_QUOTA_COUNT = ATTR_PREFIX + "quota.count";
     public static final String ATTR_REQUEST_ENDPOINT = ATTR_PREFIX + "request.endpoint";
+    public static final String ATTR_REQUEST_ENDPOINT_OVERRIDE = ATTR_PREFIX + "request.endpoint.override";
     public static final String ATTR_REQUEST_METHOD = ATTR_PREFIX + "request.method";
     public static final String ATTR_PLAN = ATTR_PREFIX + "plan";
     public static final String ATTR_SUBSCRIPTION_ID = ATTR_PREFIX + "user-id";

--- a/src/main/java/io/gravitee/gateway/jupiter/api/context/DeploymentContext.java
+++ b/src/main/java/io/gravitee/gateway/jupiter/api/context/DeploymentContext.java
@@ -16,6 +16,8 @@
 package io.gravitee.gateway.jupiter.api.context;
 
 import io.gravitee.el.TemplateEngine;
+import io.gravitee.el.TemplateVariableProvider;
+import java.util.Collection;
 
 /**
  * The {@link DeploymentContext} allows to access useful information at deployment time.

--- a/src/main/java/io/gravitee/gateway/jupiter/api/helper/PluginConfigurationHelper.java
+++ b/src/main/java/io/gravitee/gateway/jupiter/api/helper/PluginConfigurationHelper.java
@@ -13,21 +13,22 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.gravitee.gateway.jupiter.api.connector;
+package io.gravitee.gateway.jupiter.api.helper;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import io.gravitee.gateway.jupiter.api.connector.Connector;
 import io.gravitee.gateway.jupiter.api.exception.PluginConfigurationException;
 import io.gravitee.node.api.configuration.Configuration;
 import lombok.AllArgsConstructor;
 
 /**
- * Helper class used by factory to create new {@link Connector}
+ * Helper class used by factories to instantiate configuration object from json string config.
  *
  * @author Guillaume LAMIRAND (guillaume.lamirand at graviteesource.com)
  * @author GraviteeSource Team
  */
 @AllArgsConstructor
-public class ConnectorHelper {
+public class PluginConfigurationHelper {
 
     private final Configuration configuration;
     private final ObjectMapper objectMapper;

--- a/src/test/java/io/gravitee/gateway/jupiter/api/connector/PluginConfigurationHelperTest.java
+++ b/src/test/java/io/gravitee/gateway/jupiter/api/connector/PluginConfigurationHelperTest.java
@@ -20,19 +20,20 @@ import static org.junit.jupiter.api.Assertions.*;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.gravitee.gateway.jupiter.api.connector.endpoint.EndpointConnectorConfiguration;
 import io.gravitee.gateway.jupiter.api.exception.PluginConfigurationException;
+import io.gravitee.gateway.jupiter.api.helper.PluginConfigurationHelper;
 import lombok.Getter;
 import lombok.Setter;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
-class ConnectorHelperTest {
+class PluginConfigurationHelperTest {
 
-    private final ConnectorHelper connectorHelper = new ConnectorHelper(null, new ObjectMapper());
+    private final PluginConfigurationHelper pluginConfigurationHelper = new PluginConfigurationHelper(null, new ObjectMapper());
 
     @Test
     @DisplayName("getConnectorConfiguration should read JSON configuration and return configuration object")
     void shouldReadConfigurationWithValidConfiguration() throws PluginConfigurationException {
-        TestConfiguration config = connectorHelper.readConfiguration(
+        TestConfiguration config = pluginConfigurationHelper.readConfiguration(
             TestConfiguration.class,
             "{\"data1\":\"value1\", \"data2\":\"value2\"}"
         );
@@ -45,14 +46,14 @@ class ConnectorHelperTest {
     void shouldThrowPluginConfigurationExceptionWithInvalidConfiguration() {
         assertThrows(
             PluginConfigurationException.class,
-            () -> connectorHelper.readConfiguration(TestConfiguration.class, "THIS IS INVALID JSON")
+            () -> pluginConfigurationHelper.readConfiguration(TestConfiguration.class, "THIS IS INVALID JSON")
         );
     }
 
     @Test
     @DisplayName("getConnectorConfiguration should get empty configuration when configuration is null")
     void shouldGetEmptyConfigurationExceptionWithNullConfiguration() throws PluginConfigurationException {
-        TestConfiguration config = connectorHelper.readConfiguration(TestConfiguration.class, null);
+        TestConfiguration config = pluginConfigurationHelper.readConfiguration(TestConfiguration.class, null);
         assertNotNull(config);
         assertNull(config.getData1());
         assertNull(config.getData2());


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/APIM-605

**Description**

Add the concept of `ApiService` and refactor `ConnectorHelper` to `PluginConfigurationHelper` to make it usable in other contexts than connectors.
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `2.1.0-apim-605-http-healthcheck-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/gateway/gravitee-gateway-api/2.1.0-apim-605-http-healthcheck-SNAPSHOT/gravitee-gateway-api-2.1.0-apim-605-http-healthcheck-SNAPSHOT.zip)
  <!-- Version placeholder end -->
