### PR TITLE
feat: add endpoint group configuration handling for connector factory

### DIFF
--- a/src/main/java/io/gravitee/gateway/reactive/api/connector/endpoint/EndpointConnectorFactory.java
+++ b/src/main/java/io/gravitee/gateway/reactive/api/connector/endpoint/EndpointConnectorFactory.java
@@ -16,8 +16,27 @@
 package io.gravitee.gateway.reactive.api.connector.endpoint;
 
 import io.gravitee.gateway.reactive.api.connector.ConnectorFactory;
+import io.gravitee.gateway.reactive.api.context.DeploymentContext;
+import javax.annotation.Nullable;
 
 /**
  * Specialized factory for {@link EndpointConnector}
  */
-public interface EndpointConnectorFactory<T extends EndpointConnector> extends ConnectorFactory<T> {}
+public interface EndpointConnectorFactory<T extends EndpointConnector> extends ConnectorFactory<T> {
+    /**
+     * Allow creating new endpoint connector from the given strings configuration.
+     *
+     * @param deploymentContext context containing useful deployment entities (api, services, ...).
+     * @param configuration the configuration as json string.
+     * @param sharedConfiguration the shared configuration as json string.
+     *
+     * @return new connector instance.
+     */
+    default T createConnector(
+        final DeploymentContext deploymentContext,
+        final String configuration,
+        @Nullable final String sharedConfiguration
+    ) {
+        return null;
+    }
+}

--- a/src/main/java/io/gravitee/gateway/reactive/api/connector/endpoint/EndpointConnectorSharedConfiguration.java
+++ b/src/main/java/io/gravitee/gateway/reactive/api/connector/endpoint/EndpointConnectorSharedConfiguration.java
@@ -13,27 +13,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.gravitee.gateway.reactive.api.connector;
-
-import io.gravitee.gateway.reactive.api.ApiType;
-import io.gravitee.gateway.reactive.api.ConnectorMode;
-import io.gravitee.gateway.reactive.api.context.DeploymentContext;
-import java.util.Set;
+package io.gravitee.gateway.reactive.api.connector.endpoint;
 
 /**
- * Factory used to create new {@link Connector}
- *
- * @author Guillaume LAMIRAND (guillaume.lamirand at graviteesource.com)
+ * @author Yann TAVERNIER (yann.tavernier at graviteesource.com)
  * @author GraviteeSource Team
  */
-public interface ConnectorFactory<T extends Connector> {
-    /**
-     * @return {@link ApiType} supported by this connector.
-     */
-    ApiType supportedApi();
-
-    /**
-     * @return {@link ConnectorMode} supported by this connector.
-     */
-    Set<ConnectorMode> supportedModes();
-}
+public interface EndpointConnectorSharedConfiguration {}

--- a/src/main/java/io/gravitee/gateway/reactive/api/connector/entrypoint/EntrypointConnectorFactory.java
+++ b/src/main/java/io/gravitee/gateway/reactive/api/connector/entrypoint/EntrypointConnectorFactory.java
@@ -17,10 +17,21 @@ package io.gravitee.gateway.reactive.api.connector.entrypoint;
 
 import io.gravitee.gateway.reactive.api.ListenerType;
 import io.gravitee.gateway.reactive.api.connector.ConnectorFactory;
+import io.gravitee.gateway.reactive.api.context.DeploymentContext;
 
 /**
  * Specialized factory for {@link EntrypointConnector}
  */
 public interface EntrypointConnectorFactory<T extends EntrypointConnector> extends ConnectorFactory<T> {
     ListenerType supportedListenerType();
+
+    /**
+     * Allow creating new entrypoint connector from the given string configuration.
+     *
+     * @param deploymentContext context containing useful deployment entities (api, services, ...).
+     * @param configuration the configuration as json string.
+     *
+     * @return new connector instance.
+     */
+    T createConnector(final DeploymentContext deploymentContext, final String configuration);
 }


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/APIM-724

**Description**

- adds a EndpointConnectorEndpointGroupConfiguration
- specializes the createConnector method for entrypoint and endpoint, moving them down from ConnectorFactory interface

<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `2.2.0-apim-724-split-endpoint-configuration-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/gateway/gravitee-gateway-api/2.2.0-apim-724-split-endpoint-configuration-SNAPSHOT/gravitee-gateway-api-2.2.0-apim-724-split-endpoint-configuration-SNAPSHOT.zip)
  <!-- Version placeholder end -->
