### PR TITLE
fix: don't emit stop message if not required

### DIFF
--- a/src/test/java/io/gravitee/gateway/jupiter/api/connector/entrypoint/async/EntrypointAsyncConnectorImpl.java
+++ b/src/test/java/io/gravitee/gateway/jupiter/api/connector/entrypoint/async/EntrypointAsyncConnectorImpl.java
@@ -1,0 +1,70 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gateway.jupiter.api.connector.entrypoint.async;
+
+import io.gravitee.gateway.jupiter.api.ConnectorMode;
+import io.gravitee.gateway.jupiter.api.ListenerType;
+import io.gravitee.gateway.jupiter.api.context.ExecutionContext;
+import io.gravitee.gateway.jupiter.api.qos.QosRequirement;
+import io.reactivex.rxjava3.core.Completable;
+import java.util.Set;
+
+/**
+ * @author Jeoffrey HAEYAERT (jeoffrey.haeyaert at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+class EntrypointAsyncConnectorImpl extends EntrypointAsyncConnector {
+
+    @Override
+    public String id() {
+        return null;
+    }
+
+    @Override
+    public Set<ConnectorMode> supportedModes() {
+        return null;
+    }
+
+    @Override
+    public ListenerType supportedListenerType() {
+        return null;
+    }
+
+    @Override
+    public int matchCriteriaCount() {
+        return 0;
+    }
+
+    @Override
+    public boolean matches(ExecutionContext executionContext) {
+        return false;
+    }
+
+    @Override
+    public Completable handleRequest(ExecutionContext executionContext) {
+        return null;
+    }
+
+    @Override
+    public Completable handleResponse(ExecutionContext executionContext) {
+        return null;
+    }
+
+    @Override
+    public QosRequirement qosRequirement() {
+        return null;
+    }
+}

--- a/src/test/java/io/gravitee/gateway/jupiter/api/connector/entrypoint/async/EntrypointAsyncConnectorTest.java
+++ b/src/test/java/io/gravitee/gateway/jupiter/api/connector/entrypoint/async/EntrypointAsyncConnectorTest.java
@@ -1,0 +1,75 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gateway.jupiter.api.connector.entrypoint.async;
+
+import static io.gravitee.gateway.jupiter.api.connector.entrypoint.async.EntrypointAsyncConnector.STOP_MESSAGE_ID;
+
+import io.gravitee.gateway.jupiter.api.message.DefaultMessage;
+import io.gravitee.gateway.jupiter.api.message.Message;
+import io.reactivex.rxjava3.core.Flowable;
+import io.reactivex.rxjava3.schedulers.TestScheduler;
+import io.reactivex.rxjava3.subscribers.TestSubscriber;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.Test;
+
+/**
+ * @author Jeoffrey HAEYAERT (jeoffrey.haeyaert at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+class EntrypointAsyncConnectorTest {
+
+    private final EntrypointAsyncConnectorImpl cut = new EntrypointAsyncConnectorImpl();
+
+    @Test
+    void should_emit_stop_message() throws Exception {
+        final TestScheduler testScheduler = new TestScheduler();
+        final Flowable<DefaultMessage> messages = Flowable
+            .interval(10, TimeUnit.MILLISECONDS, testScheduler)
+            .map(i -> DefaultMessage.builder().build());
+        final TestSubscriber<Message> obs = messages.compose(cut.applyStopHook()).test();
+
+        obs.assertNotComplete();
+        testScheduler.advanceTimeBy(50, TimeUnit.MILLISECONDS);
+        testScheduler.triggerActions();
+        obs.assertNotComplete();
+
+        cut.emitStopMessage();
+        obs.assertComplete();
+
+        obs.assertValueCount(6);
+        obs.assertValueAt(5, message -> message.id().equals(STOP_MESSAGE_ID));
+    }
+
+    @Test
+    void should_not_emit_stop_message_when_already_cancelled() throws Exception {
+        final TestScheduler testScheduler = new TestScheduler();
+        final Flowable<DefaultMessage> messages = Flowable
+            .interval(10, TimeUnit.MILLISECONDS, testScheduler)
+            .map(i -> DefaultMessage.builder().build());
+        final TestSubscriber<Message> obs = messages.compose(cut.applyStopHook()).test();
+
+        obs.assertNotComplete();
+        testScheduler.advanceTimeBy(50, TimeUnit.MILLISECONDS);
+        testScheduler.triggerActions();
+        obs.assertNotComplete();
+        obs.cancel();
+
+        cut.emitStopMessage();
+        obs.assertNotComplete();
+
+        obs.assertValueCount(5);
+    }
+}


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/ARCHI-225

**Description**

Make sure to send a stop message only when necessary (ie: there are still active subscribers).
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `2.1.0-achi-225-fix-stop-message-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/gateway/gravitee-gateway-api/2.1.0-achi-225-fix-stop-message-SNAPSHOT/gravitee-gateway-api-2.1.0-achi-225-fix-stop-message-SNAPSHOT.zip)
  <!-- Version placeholder end -->
