### PR TITLE
fix(deps): upgrade alpha version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -33,15 +33,14 @@
     <name>Gravitee.io APIM - Gateway - API</name>
 
     <properties>
-        <gravitee-bom.version>3.0.0</gravitee-bom.version>
+        <gravitee-bom.version>4.0.0</gravitee-bom.version>
         <gravitee-tracing-api.version>1.0.0</gravitee-tracing-api.version>
-        <gravitee-common.version>2.1.0-alpha.3</gravitee-common.version>
+        <gravitee-common.version>2.1.0</gravitee-common.version>
         <gravitee-policy-api.version>1.11.0</gravitee-policy-api.version>
-        <gravitee-reporter-api.version>1.25.0-alpha.4</gravitee-reporter-api.version>
-        <gravitee-expression-language.version>2.1.0-alpha.1</gravitee-expression-language.version>
+        <gravitee-reporter-api.version>1.25.0</gravitee-reporter-api.version>
+        <gravitee-expression-language.version>2.1.0</gravitee-expression-language.version>
         <gravitee-apim-gateway-buffer.version>3.19.0</gravitee-apim-gateway-buffer.version>
     </properties>
-
 
     <dependencyManagement>
         <dependencies>

--- a/src/test/java/io/gravitee/gateway/reactive/api/connector/entrypoint/async/EntrypointAsyncConnectorImpl.java
+++ b/src/test/java/io/gravitee/gateway/reactive/api/connector/entrypoint/async/EntrypointAsyncConnectorImpl.java
@@ -13,12 +13,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.gravitee.gateway.jupiter.api.connector.entrypoint.async;
+package io.gravitee.gateway.reactive.api.connector.entrypoint.async;
 
-import io.gravitee.gateway.jupiter.api.ConnectorMode;
-import io.gravitee.gateway.jupiter.api.ListenerType;
-import io.gravitee.gateway.jupiter.api.context.ExecutionContext;
-import io.gravitee.gateway.jupiter.api.qos.QosRequirement;
+import io.gravitee.gateway.reactive.api.ConnectorMode;
+import io.gravitee.gateway.reactive.api.ListenerType;
+import io.gravitee.gateway.reactive.api.context.ExecutionContext;
+import io.gravitee.gateway.reactive.api.qos.QosRequirement;
 import io.reactivex.rxjava3.core.Completable;
 import java.util.Set;
 

--- a/src/test/java/io/gravitee/gateway/reactive/api/connector/entrypoint/async/EntrypointAsyncConnectorTest.java
+++ b/src/test/java/io/gravitee/gateway/reactive/api/connector/entrypoint/async/EntrypointAsyncConnectorTest.java
@@ -13,12 +13,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.gravitee.gateway.jupiter.api.connector.entrypoint.async;
+package io.gravitee.gateway.reactive.api.connector.entrypoint.async;
 
-import static io.gravitee.gateway.jupiter.api.connector.entrypoint.async.EntrypointAsyncConnector.STOP_MESSAGE_ID;
+import static io.gravitee.gateway.reactive.api.connector.entrypoint.async.EntrypointAsyncConnector.STOP_MESSAGE_ID;
 
-import io.gravitee.gateway.jupiter.api.message.DefaultMessage;
-import io.gravitee.gateway.jupiter.api.message.Message;
+import io.gravitee.gateway.reactive.api.message.DefaultMessage;
+import io.gravitee.gateway.reactive.api.message.Message;
 import io.reactivex.rxjava3.core.Flowable;
 import io.reactivex.rxjava3.schedulers.TestScheduler;
 import io.reactivex.rxjava3.subscribers.TestSubscriber;


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/issues/issues/XXXXX

**Description**

A small description of what you did in that PR.

**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `2.1.0-upgrade-deps-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/gateway/gravitee-gateway-api/2.1.0-upgrade-deps-SNAPSHOT/gravitee-gateway-api-2.1.0-upgrade-deps-SNAPSHOT.zip)
  <!-- Version placeholder end -->
