### PR TITLE
chore: bump el version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -38,7 +38,7 @@
         <gravitee-common.version>2.1.0</gravitee-common.version>
         <gravitee-policy-api.version>1.11.0</gravitee-policy-api.version>
         <gravitee-reporter-api.version>1.25.0</gravitee-reporter-api.version>
-        <gravitee-expression-language.version>2.1.0</gravitee-expression-language.version>
+        <gravitee-expression-language.version>2.2.0</gravitee-expression-language.version>
         <gravitee-apim-gateway-buffer.version>3.19.0</gravitee-apim-gateway-buffer.version>
     </properties>
 

--- a/src/main/java/io/gravitee/gateway/reactive/api/connector/endpoint/EndpointConnectorFactory.java
+++ b/src/main/java/io/gravitee/gateway/reactive/api/connector/endpoint/EndpointConnectorFactory.java
@@ -17,7 +17,6 @@ package io.gravitee.gateway.reactive.api.connector.endpoint;
 
 import io.gravitee.gateway.reactive.api.connector.ConnectorFactory;
 import io.gravitee.gateway.reactive.api.context.DeploymentContext;
-import javax.annotation.Nullable;
 
 /**
  * Specialized factory for {@link EndpointConnector}
@@ -32,11 +31,7 @@ public interface EndpointConnectorFactory<T extends EndpointConnector> extends C
      *
      * @return new connector instance.
      */
-    default T createConnector(
-        final DeploymentContext deploymentContext,
-        final String configuration,
-        @Nullable final String sharedConfiguration
-    ) {
+    default T createConnector(final DeploymentContext deploymentContext, final String configuration, final String sharedConfiguration) {
         return null;
     }
 }


### PR DESCRIPTION
**Description**

Bump el expression version

<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `3.0.0-bump-expression-language-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/gateway/gravitee-gateway-api/3.0.0-bump-expression-language-SNAPSHOT/gravitee-gateway-api-3.0.0-bump-expression-language-SNAPSHOT.zip)
  <!-- Version placeholder end -->
