### PR TITLE
feat: add writePing method to WebSocket

### DIFF
--- a/src/main/java/io/gravitee/gateway/reactive/api/ws/WebSocket.java
+++ b/src/main/java/io/gravitee/gateway/reactive/api/ws/WebSocket.java
@@ -42,6 +42,17 @@ public interface WebSocket {
     Completable write(Buffer buffer);
 
     /**
+     * Writes a ping frame to the connection.
+     * <p>
+     * This method should only be used for implementing a keep alive or to ensure the client is still responsive,
+     * see RFC 6455 Section <a href="https://tools.ietf.org/html/rfc6455#section-5.5.2">section 5.5.2</a>.
+     * <p>
+     *
+     * @return a {@link Completable} that completes once writing has been performed.
+     */
+    Completable writePing();
+
+    /**
      * Returns the websocket incoming {@link Flowable} of {@link Buffer}.
      *
      * @return a {@link Flowable} of {@link Buffer}.


### PR DESCRIPTION
**Description**

Add `writePing` method to WebSocket interface.

**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `3.0.0-add-write-ping-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/gateway/gravitee-gateway-api/3.0.0-add-write-ping-SNAPSHOT/gravitee-gateway-api-3.0.0-add-write-ping-SNAPSHOT.zip)
  <!-- Version placeholder end -->
