### PR TITLE
fix: update subscription type to PUSH

### DIFF
--- a/src/main/java/io/gravitee/gateway/api/service/Subscription.java
+++ b/src/main/java/io/gravitee/gateway/api/service/Subscription.java
@@ -70,7 +70,7 @@ public class Subscription {
 
     public enum Type {
         STANDARD,
-        SUBSCRIPTION,
+        PUSH,
     }
 
     public enum ConsumerStatus {


### PR DESCRIPTION
related to APIM-719

<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `3.0.0-apim-719-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/gateway/gravitee-gateway-api/3.0.0-apim-719-SNAPSHOT/gravitee-gateway-api-3.0.0-apim-719-SNAPSHOT.zip)
  <!-- Version placeholder end -->
