### PR TITLE
Fix evaluable message

### DIFF
--- a/src/main/java/io/gravitee/gateway/reactive/api/context/GenericExecutionContext.java
+++ b/src/main/java/io/gravitee/gateway/reactive/api/context/GenericExecutionContext.java
@@ -17,7 +17,6 @@ package io.gravitee.gateway.reactive.api.context;
 
 import io.gravitee.el.TemplateEngine;
 import io.gravitee.reporter.api.v4.metric.Metrics;
-
 import java.util.List;
 import java.util.Map;
 import java.util.Set;

--- a/src/main/java/io/gravitee/gateway/reactive/api/el/EvaluableMessage.java
+++ b/src/main/java/io/gravitee/gateway/reactive/api/el/EvaluableMessage.java
@@ -32,35 +32,35 @@ public class EvaluableMessage {
         this.message = message;
     }
 
-    public Set<String> attributeNames() {
+    public Set<String> geAttributeNames() {
         return message.attributeNames();
     }
 
-    public <T> Map<String, T> attributes() {
+    public <T> Map<String, T> getAttributes() {
         return message.attributes();
     }
 
-    public String id() {
+    public String getId() {
         return message.id();
     }
 
-    public boolean error() {
+    public boolean getError() {
         return message.error();
     }
 
-    public Map<String, Object> metadata() {
+    public Map<String, Object> getMetadata() {
         return message.metadata();
     }
 
-    public HttpHeaders headers() {
+    public HttpHeaders getHeaders() {
         return message.headers();
     }
 
-    public String content() {
+    public String getContent() {
         return message.content().toString();
     }
 
-    public int contentLength() {
+    public int getContentLength() {
         return message.content().length();
     }
 }


### PR DESCRIPTION
**Issue**

APIM-1622

**Description**

Some policies are using Freemarker as template engine, to keep the same syntaxe to access the Message attributes (`message.content` / `message.headers['my-header'][0]` ) the attributes accessor need to follow the Java getter syntaxe.
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `3.0.0-fix-evaluable-message-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/gateway/gravitee-gateway-api/3.0.0-fix-evaluable-message-SNAPSHOT/gravitee-gateway-api-3.0.0-fix-evaluable-message-SNAPSHOT.zip)
  <!-- Version placeholder end -->
