### PR TITLE
fix: define common ERROR KEY for AsyncEndpoints

### DIFF
--- a/src/main/java/io/gravitee/gateway/reactive/api/connector/endpoint/async/EndpointAsyncConnector.java
+++ b/src/main/java/io/gravitee/gateway/reactive/api/connector/endpoint/async/EndpointAsyncConnector.java
@@ -35,6 +35,15 @@ import java.util.Set;
  * Specialized {@link EndpointConnector} for {@link ApiType#MESSAGE}
  */
 public abstract class EndpointAsyncConnector extends AbstractService<Connector> implements EndpointConnector {
+    public static final String FAILURE_ENDPOINT_CONNECTION_FAILED = "FAILURE_ENDPOINT_CONNECTION_FAILED";
+    public static final String FAILURE_ENDPOINT_CONNECTION_CLOSED = "FAILURE_ENDPOINT_CONNECTION_CLOSED";
+    public static final String FAILURE_ENDPOINT_CONFIGURATION_INVALID = "FAILURE_ENDPOINT_CONFIGURATION_INVALID";
+    public static final String FAILURE_ENDPOINT_UNKNOWN_ERROR = "FAILURE_ENDPOINT_UNKNOWN_ERROR";
+
+    public static final String FAILURE_ENDPOINT_PUBLISH_FAILED = "FAILURE_ENDPOINT_PUBLISH_FAILED";
+    public static final String FAILURE_ENDPOINT_SUBSCRIBE_FAILED = "FAILURE_ENDPOINT_SUBSCRIBE_FAILED";
+    public static final String FAILURE_PARAMETERS_EXCEPTION = "exception";
+    public static final int DEFAULT_FAILURE_CODE = 500;
 
     @Override
     public ApiType supportedApi() {


### PR DESCRIPTION
fix APIM-323
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `3.0.0-apim-323-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/gateway/gravitee-gateway-api/3.0.0-apim-323-SNAPSHOT/gravitee-gateway-api-3.0.0-apim-323-SNAPSHOT.zip)
  <!-- Version placeholder end -->
