### PR TITLE
feat: add method to get list from an message attribute

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -35,7 +35,7 @@
     <properties>
         <gravitee-bom.version>6.0.1</gravitee-bom.version>
         <gravitee-tracing-api.version>1.0.0</gravitee-tracing-api.version>
-        <gravitee-common.version>2.1.1</gravitee-common.version>
+        <gravitee-common.version>3.0.0</gravitee-common.version>
         <gravitee-policy-api.version>1.11.0</gravitee-policy-api.version>
         <gravitee-reporter-api.version>1.25.0</gravitee-reporter-api.version>
         <gravitee-expression-language.version>2.2.1</gravitee-expression-language.version>

--- a/src/main/java/io/gravitee/gateway/reactive/api/message/DefaultMessage.java
+++ b/src/main/java/io/gravitee/gateway/reactive/api/message/DefaultMessage.java
@@ -15,10 +15,12 @@
  */
 package io.gravitee.gateway.reactive.api.message;
 
+import io.gravitee.common.util.ListUtils;
 import io.gravitee.gateway.api.buffer.Buffer;
 import io.gravitee.gateway.api.http.HttpHeaders;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
@@ -79,6 +81,11 @@ public class DefaultMessage implements Message {
     @Override
     public <T> T attribute(final String name) {
         return (T) getOrInitAttribute().get(name);
+    }
+
+    @Override
+    public <T> List<T> attributeAsList(String name) {
+        return ListUtils.toList(getOrInitAttribute().get(name));
     }
 
     @Override

--- a/src/main/java/io/gravitee/gateway/reactive/api/message/Message.java
+++ b/src/main/java/io/gravitee/gateway/reactive/api/message/Message.java
@@ -17,6 +17,7 @@ package io.gravitee.gateway.reactive.api.message;
 
 import io.gravitee.gateway.api.buffer.Buffer;
 import io.gravitee.gateway.api.http.HttpHeaders;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
@@ -128,6 +129,42 @@ public interface Message {
      * @return an Object containing the value of the attribute, or null if the attribute does not exist.
      */
     <T> T attribute(final String name);
+
+    /**
+     * Return the attribute as an immutable {@link List}.
+     * This method acts differently depending on the type of the attribute's value.
+     * Elements of the {@link List} are mapped as follows:
+     * <p>
+     * <b>For String:</b>
+     *     <ul>
+     *          <li>comma separated string are spitted and returned trimmed</li>
+     *          <li>Parsable JSON Array elements are returned as strings (including objects)</li>
+     *          <li>if none of the above, the string is simply wrapped</li>
+     *      </ul>
+     * </p>
+     * <p>
+     *     <b>For Collection:</b>
+     *     <ul>
+     *         <li>Elements of the collection are wrapped in a new List</li>
+     *     </ul>
+     * </p>
+     * <p>
+     *     <b>For Array:</b>
+     *     <ul>
+     *         <li>Each elements of the is wrapped into the returned List</li>
+     *     </ul>
+     * </p>
+     * <p>
+     * <b>For any other cases:</b> the value is simply wrapped into the returned List.
+     * <b>Notes:</b>
+     * One calling {@link #attribute(String, Object)} with a mutable collection will retrieve an immutable one.
+     * </p>
+     *
+     * @param name the name of the attribute.
+     * @param <T>  the expected type of the attribute value. Specify {@link Object} if you expect value of any type.
+     * @return an immutable List with the attribute values.
+     */
+    <T> List<T> attributeAsList(String name);
 
     /**
      * Stores an attribute in this message.


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/APIM-2552

**Description**

Allow to get message attribute as a list
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `3.1.0-apim-2552-kafka-topic-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/gateway/gravitee-gateway-api/3.1.0-apim-2552-kafka-topic-SNAPSHOT/gravitee-gateway-api-3.1.0-apim-2552-kafka-topic-SNAPSHOT.zip)
  <!-- Version placeholder end -->
