### PR TITLE
feat: add support for DBLess mode

### DIFF
--- a/src/main/java/io/gravitee/gateway/api/ExecutionContext.java
+++ b/src/main/java/io/gravitee/gateway/api/ExecutionContext.java
@@ -54,6 +54,7 @@ public interface ExecutionContext {
      */
     String ATTR_SECURITY_SKIP = "skip-security-chain";
     String ATTR_INVOKER_SKIP = "invoker.skip";
+    String ATTR_VALIDATE_SUBSCRIPTION = "api.validateSubscription";
 
     Request request();
 

--- a/src/main/java/io/gravitee/gateway/reactive/api/context/InternalContextAttributes.java
+++ b/src/main/java/io/gravitee/gateway/reactive/api/context/InternalContextAttributes.java
@@ -42,6 +42,7 @@ public final class InternalContextAttributes {
     public static final String ATTR_INTERNAL_ANALYTICS_CONTEXT = "analytics.context";
     public static final String ATTR_INTERNAL_MESSAGE_RECORDABLE = "message.recordable";
     public static final String ATTR_INTERNAL_MESSAGE_RECORDABLE_WITH_LOGGING = "message.recordable.withLogging";
+    public static final String ATTR_INTERNAL_VALIDATE_SUBSCRIPTION = "api.validateSubscription";
 
     /**
      * Adapted ExecutionContext for V3 compatibility.


### PR DESCRIPTION
sync commit merged on alpha by mistake 
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `3.2.0-alpha-rebased-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/gateway/gravitee-gateway-api/3.2.0-alpha-rebased-SNAPSHOT/gravitee-gateway-api-3.2.0-alpha-rebased-SNAPSHOT.zip)
  <!-- Version placeholder end -->
