### PR TITLE
feat: allow to create ExecutionFailure without status code

### DIFF
--- a/src/main/java/io/gravitee/gateway/reactive/api/ExecutionFailure.java
+++ b/src/main/java/io/gravitee/gateway/reactive/api/ExecutionFailure.java
@@ -31,6 +31,8 @@ public class ExecutionFailure {
     private Map<String, Object> parameters;
     private String contentType;
 
+    public ExecutionFailure() {}
+
     public ExecutionFailure(int statusCode) {
         this.statusCode = statusCode;
     }


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/ARCHI-267

**Description**

Allow to instantiate an ExecutionFailure without a status code.
This is useful when you need to interrupt the chain in the context of an tcp-proxy api, which is not related with HTTP status
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `3.4.0-archi-267-tcp-proxy-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/gateway/gravitee-gateway-api/3.4.0-archi-267-tcp-proxy-SNAPSHOT/gravitee-gateway-api-3.4.0-archi-267-tcp-proxy-SNAPSHOT.zip)
  <!-- Version placeholder end -->
