### PR TITLE
fix: add internal attribute if error during security token extraction

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
 
     <groupId>io.gravitee.gateway</groupId>
     <artifactId>gravitee-gateway-api</artifactId>
-    <version>3.2.1</version>
+    <version>3.2.2-apim-3382-SNAPSHOT</version>
     <name>Gravitee.io APIM - Gateway - API</name>
 
     <properties>

--- a/src/main/java/io/gravitee/gateway/reactive/api/context/InternalContextAttributes.java
+++ b/src/main/java/io/gravitee/gateway/reactive/api/context/InternalContextAttributes.java
@@ -38,6 +38,7 @@ public final class InternalContextAttributes {
     public static final String ATTR_INTERNAL_SUBSCRIPTION = "subscription";
     public static final String ATTR_INTERNAL_SUBSCRIPTION_TYPE = "subscriptionType";
     public static final String ATTR_INTERNAL_SECURITY_TOKEN = "securityChain.securityToken";
+    public static final String ATTR_INTERNAL_SECURITY_TOKEN_EXTRACTION_FAILURE = "securityChain.securityToken.extractionFailure";
     public static final String ATTR_INTERNAL_SECURITY_SKIP = "securityChain.skip";
     public static final String ATTR_INTERNAL_ANALYTICS_CONTEXT = "analytics.context";
     public static final String ATTR_INTERNAL_MESSAGE_RECORDABLE = "message.recordable";


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/APIM-3382

**Description**

Add internal attribute if error during security token extraction
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `3.2.2-apim-3382-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/gateway/gravitee-gateway-api/3.2.2-apim-3382-SNAPSHOT/gravitee-gateway-api-3.2.2-apim-3382-SNAPSHOT.zip)
  <!-- Version placeholder end -->
