### PR TITLE
fix(deps): Bump gravitee-reporter-api to version 1.31.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -37,7 +37,7 @@
         <gravitee-tracing-api.version>1.0.0</gravitee-tracing-api.version>
         <gravitee-common.version>3.0.0</gravitee-common.version>
         <gravitee-policy-api.version>1.11.0</gravitee-policy-api.version>
-        <gravitee-reporter-api.version>1.26.0</gravitee-reporter-api.version>
+        <gravitee-reporter-api.version>1.31.2</gravitee-reporter-api.version>
         <gravitee-expression-language.version>3.1.0</gravitee-expression-language.version>
         <gravitee-apim-gateway-buffer.version>3.19.0</gravitee-apim-gateway-buffer.version>
 


### PR DESCRIPTION
**Description**

Update gravitee-reporter-api

**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `3.5.2-fix-deps-bump-gravitee-reporter-api-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/gateway/gravitee-gateway-api/3.5.2-fix-deps-bump-gravitee-reporter-api-SNAPSHOT/gravitee-gateway-api-3.5.2-fix-deps-bump-gravitee-reporter-api-SNAPSHOT.zip)
  <!-- Version placeholder end -->
