### PR TITLE
feat: deprecate SslSession in favor of TlsSession

### DIFF
--- a/src/main/java/io/gravitee/gateway/reactive/api/context/GenericRequest.java
+++ b/src/main/java/io/gravitee/gateway/reactive/api/context/GenericRequest.java
@@ -19,7 +19,6 @@ import io.gravitee.common.http.HttpMethod;
 import io.gravitee.common.http.HttpVersion;
 import io.gravitee.common.util.MultiValueMap;
 import io.gravitee.gateway.api.http.HttpHeaders;
-import io.gravitee.reporter.api.http.Metrics;
 import javax.net.ssl.SSLSession;
 
 public interface GenericRequest {
@@ -128,8 +127,16 @@ public interface GenericRequest {
     /**
      * @return SSLSession associated to the request. Returns <code>null</code> if not an SSL connection.
      * @see javax.net.ssl.SSLSession
+     * @deprecated use {@link #tlsSession()} instead
      */
+    @Deprecated(since = "4.5.0", forRemoval = true)
     SSLSession sslSession();
+
+    /**
+     * @return TlsSession associated to the request. Acts as a SSLSession, with additional mechanisms. It can for example extract a client certificate from a given header.
+     * @see javax.net.ssl.SSLSession
+     */
+    TlsSession tlsSession();
 
     /**
      * Indicates if that request is ended or not meaning that all the request headers and the request body have been fully read.

--- a/src/main/java/io/gravitee/gateway/reactive/api/context/TlsSession.java
+++ b/src/main/java/io/gravitee/gateway/reactive/api/context/TlsSession.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gateway.reactive.api.context;
+
+import javax.net.ssl.SSLSession;
+
+public interface TlsSession extends SSLSession {
+    /**
+     * @return true if request is an SSL connection
+     */
+    boolean isSSLConnection();
+}


### PR DESCRIPTION
https://gravitee.atlassian.net/browse/APIM-3987
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `3.8.0-apim-3987-tls-session-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/gateway/gravitee-gateway-api/3.8.0-apim-3987-tls-session-SNAPSHOT/gravitee-gateway-api-3.8.0-apim-3987-tls-session-SNAPSHOT.zip)
  <!-- Version placeholder end -->
