### PR TITLE
fix: add environmentId in subscription [ 3.8.x ]

### DIFF
--- a/src/main/java/io/gravitee/gateway/api/service/Subscription.java
+++ b/src/main/java/io/gravitee/gateway/api/service/Subscription.java
@@ -65,6 +65,8 @@ public class Subscription {
     @EqualsAndHashCode.Exclude
     private boolean forceDispatch;
 
+    private String environmentId;
+
     public boolean isTimeValid(long requestTimestamp) {
         Date requestDate = new Date(requestTimestamp);
         return (endingAt == null || endingAt.after(requestDate)) && (startingAt == null || startingAt.before(requestDate));


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/APIM-6600

**Description**

Add environmentId in subscription

**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `3.8.1-apim-6600-add-envid-in-subscription-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/gateway/gravitee-gateway-api/3.8.1-apim-6600-add-envid-in-subscription-SNAPSHOT/gravitee-gateway-api-3.8.1-apim-6600-add-envid-in-subscription-SNAPSHOT.zip)
  <!-- Version placeholder end -->
