### PR TITLE
fix: adapt interfaces to prepare for apim switch

### DIFF
--- a/src/main/java/io/gravitee/gateway/reactive/api/context/base/BaseMessageExecutionContext.java
+++ b/src/main/java/io/gravitee/gateway/reactive/api/context/base/BaseMessageExecutionContext.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gateway.reactive.api.context.base;
+
+import io.gravitee.el.TemplateEngine;
+import io.gravitee.gateway.reactive.api.message.Message;
+import io.reactivex.rxjava3.core.Flowable;
+import io.reactivex.rxjava3.core.Maybe;
+
+/**
+ * Base interface any message execution context interface can inherit from.
+ *
+ * @author Jeoffrey HAEYAERT (jeoffrey.haeyaert at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+public interface BaseMessageExecutionContext extends BaseExecutionContext {
+    String TEMPLATE_ATTRIBUTE_MESSAGE = "message";
+
+    /**
+     * Interrupts the current execution while indicating that the flow of messages can be consumed "as is" to the downstream.
+     * This has direct impact on how the remaining execution flow will behave (ex: remaining policies in a policy chain won't be executed).
+     */
+    Flowable<Message> interruptMessages();
+
+    /**
+     * Same as {@link BaseMessageExecutionContext#interruptMessages} but at message level
+     */
+    Maybe<Message> interruptMessage();
+
+    /**
+     * Get the {@link TemplateEngine} that can be used to evaluate EL expressions.
+     *
+     * @return the El {@link TemplateEngine}.
+     */
+    TemplateEngine getTemplateEngine(Message message);
+}

--- a/src/main/java/io/gravitee/gateway/reactive/api/context/base/BaseMessageRequest.java
+++ b/src/main/java/io/gravitee/gateway/reactive/api/context/base/BaseMessageRequest.java
@@ -13,9 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.gravitee.gateway.reactive.api.context.http;
+package io.gravitee.gateway.reactive.api.context.base;
 
-import io.gravitee.gateway.reactive.api.context.base.BaseMessageResponse;
+import io.gravitee.gateway.reactive.api.context.http.HttpBaseRequest;
 import io.gravitee.gateway.reactive.api.message.Message;
 import io.reactivex.rxjava3.core.Completable;
 import io.reactivex.rxjava3.core.Flowable;
@@ -24,14 +24,14 @@ import io.reactivex.rxjava3.core.Maybe;
 import java.util.function.Function;
 
 /**
- * Represents a response that can manipulate a flow of messages.
+ * Represents a request that can manipulate a flow of messages.
  *
- * @author Guillaume LAMIRAND (guillaume.lamirand at graviteesource.com)
+ * @author Jeoffrey HAEYAERT (jeoffrey.haeyaert at graviteesource.com)
  * @author GraviteeSource Team
  */
-public interface HttpMessageResponse extends BaseMessageResponse, HttpBaseResponse {
+public interface BaseMessageRequest extends BaseRequest {
     /**
-     * Get the response message flow as a {@link Flowable} of {@link Message}.
+     * Get the request message flow as a {@link Flowable} of {@link Message}.
      * <b>WARN:</b> you should not keep a direct reference on the message flow as it could be overridden by others at anytime.
      *
      * @return a {@link Flowable} of {@link Message}.
@@ -39,7 +39,7 @@ public interface HttpMessageResponse extends BaseMessageResponse, HttpBaseRespon
     Flowable<Message> messages();
 
     /**
-     * Set the response message flow.
+     * Set the request message flow.
      * <b>WARN:</b>
      * <ul>
      *  <li>Replacing the message flow <b>DOES NOT</b> take care of the previous message flow in place.</li>
@@ -56,7 +56,7 @@ public interface HttpMessageResponse extends BaseMessageResponse, HttpBaseRespon
      * Applies a given transformation on each message.
      * Ex:
      * <code>
-     *     response.onMessages(messages -> messages.flatMap(message -> transformMyMessage(message)));
+     *     request.onMessages(messages -> messages.flatMap(message -> transformMyMessage(message)));
      * </code>
      *
      * @param onMessages the transformer that will be applied on each message.
@@ -69,12 +69,12 @@ public interface HttpMessageResponse extends BaseMessageResponse, HttpBaseRespon
      * Ex:
      * Discard a message:
      * <code>
-     *     response.onMessage(message -> Maybe.empty());
+     *     request.onMessage(message -> Maybe.empty());
      * </code>
      *
      * Update a message:
      * <code>
-     *     response.onMessage(message -> transformMyMessage(message));
+     *     request.onMessage(message -> transformMyMessage(message));
      * </code>
      *
      * @param onMessage the transformer that will be applied on each message.

--- a/src/main/java/io/gravitee/gateway/reactive/api/context/base/BaseMessageResponse.java
+++ b/src/main/java/io/gravitee/gateway/reactive/api/context/base/BaseMessageResponse.java
@@ -13,9 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.gravitee.gateway.reactive.api.context.http;
+package io.gravitee.gateway.reactive.api.context.base;
 
-import io.gravitee.gateway.reactive.api.context.base.BaseMessageResponse;
+import io.gravitee.gateway.reactive.api.context.http.HttpBaseResponse;
 import io.gravitee.gateway.reactive.api.message.Message;
 import io.reactivex.rxjava3.core.Completable;
 import io.reactivex.rxjava3.core.Flowable;
@@ -26,10 +26,10 @@ import java.util.function.Function;
 /**
  * Represents a response that can manipulate a flow of messages.
  *
- * @author Guillaume LAMIRAND (guillaume.lamirand at graviteesource.com)
+ * @author Jeoffrey HAEYAERT (jeoffrey.haeyaert at graviteesource.com)
  * @author GraviteeSource Team
  */
-public interface HttpMessageResponse extends BaseMessageResponse, HttpBaseResponse {
+public interface BaseMessageResponse extends BaseResponse {
     /**
      * Get the response message flow as a {@link Flowable} of {@link Message}.
      * <b>WARN:</b> you should not keep a direct reference on the message flow as it could be overridden by others at anytime.

--- a/src/main/java/io/gravitee/gateway/reactive/api/context/http/HttpMessageExecutionContext.java
+++ b/src/main/java/io/gravitee/gateway/reactive/api/context/http/HttpMessageExecutionContext.java
@@ -15,8 +15,8 @@
  */
 package io.gravitee.gateway.reactive.api.context.http;
 
-import io.gravitee.el.TemplateEngine;
 import io.gravitee.gateway.reactive.api.ExecutionFailure;
+import io.gravitee.gateway.reactive.api.context.base.BaseMessageExecutionContext;
 import io.gravitee.gateway.reactive.api.message.Message;
 import io.reactivex.rxjava3.core.Flowable;
 import io.reactivex.rxjava3.core.Maybe;
@@ -27,7 +27,7 @@ import io.reactivex.rxjava3.core.Maybe;
  *  @author Jeoffrey HAEYAERT (jeoffrey.haeyaert at graviteesource.com)
  *  @author GraviteeSource Team
  */
-public interface HttpMessageExecutionContext extends HttpBaseExecutionContext {
+public interface HttpMessageExecutionContext extends HttpBaseExecutionContext, BaseMessageExecutionContext {
     String TEMPLATE_ATTRIBUTE_MESSAGE = "message";
 
     /**
@@ -45,30 +45,12 @@ public interface HttpMessageExecutionContext extends HttpBaseExecutionContext {
     HttpMessageResponse response();
 
     /**
-     * Interrupts the current execution while indicating that the flow of messages can be consumed "as is" to the downstream.
-     * This has direct impact on how the remaining execution flow will behave (ex: remaining policies in a policy chain won't be executed).
-     */
-    Flowable<Message> interruptMessages();
-
-    /**
      * Same as {@link #interruptMessages()} but with an {@link ExecutionFailure} object that indicates that the execution has failed. The {@link ExecutionFailure} can be processed in order to build a proper response (ex: based on templating, with appropriate accept-encoding, ...).
      */
     Flowable<Message> interruptMessagesWith(final ExecutionFailure failure);
 
     /**
-     * Same as {@link HttpMessageExecutionContext#interruptMessages} but at message level
-     */
-    Maybe<Message> interruptMessage();
-
-    /**
-     * Same as {@link HttpMessageExecutionContext#interruptMessagesWith(ExecutionFailure)} but at message level
+     * Same as {@link BaseMessageExecutionContext#interruptMessagesWith(ExecutionFailure)} but at message level
      */
     Maybe<Message> interruptMessageWith(final ExecutionFailure failure);
-
-    /**
-     * Get the {@link TemplateEngine} that can be used to evaluate EL expressions.
-     *
-     * @return the El {@link TemplateEngine}.
-     */
-    TemplateEngine getTemplateEngine(Message message);
 }

--- a/src/main/java/io/gravitee/gateway/reactive/api/context/http/HttpMessageRequest.java
+++ b/src/main/java/io/gravitee/gateway/reactive/api/context/http/HttpMessageRequest.java
@@ -15,6 +15,7 @@
  */
 package io.gravitee.gateway.reactive.api.context.http;
 
+import io.gravitee.gateway.reactive.api.context.base.BaseMessageRequest;
 import io.gravitee.gateway.reactive.api.message.Message;
 import io.reactivex.rxjava3.core.Completable;
 import io.reactivex.rxjava3.core.Flowable;
@@ -28,7 +29,7 @@ import java.util.function.Function;
  * @author Guillaume LAMIRAND (guillaume.lamirand at graviteesource.com)
  * @author GraviteeSource Team
  */
-public interface HttpMessageRequest extends HttpBaseRequest {
+public interface HttpMessageRequest extends BaseMessageRequest, HttpBaseRequest {
     /**
      * Get the request message flow as a {@link Flowable} of {@link Message}.
      * <b>WARN:</b> you should not keep a direct reference on the message flow as it could be overridden by others at anytime.

--- a/src/main/java/io/gravitee/gateway/reactive/api/context/http/HttpPlainResponse.java
+++ b/src/main/java/io/gravitee/gateway/reactive/api/context/http/HttpPlainResponse.java
@@ -16,7 +16,6 @@
 package io.gravitee.gateway.reactive.api.context.http;
 
 import io.gravitee.gateway.api.buffer.Buffer;
-import io.gravitee.gateway.reactive.api.context.GenericExecutionContext;
 import io.reactivex.rxjava3.core.*;
 
 /**
@@ -143,7 +142,7 @@ public interface HttpPlainResponse extends HttpBaseResponse {
      *
      * @return an observable that can be easily chained.
      */
-    Completable end(GenericExecutionContext ctx);
+    Completable end(HttpBaseExecutionContext ctx);
 
     /**
      * Set the `Content-Length` header to the response.

--- a/src/main/java/io/gravitee/gateway/reactive/api/el/EvaluableRequest.java
+++ b/src/main/java/io/gravitee/gateway/reactive/api/el/EvaluableRequest.java
@@ -18,21 +18,21 @@ package io.gravitee.gateway.reactive.api.el;
 import io.gravitee.common.util.MultiValueMap;
 import io.gravitee.gateway.api.el.EvaluableSSLSession;
 import io.gravitee.gateway.api.http.HttpHeaders;
-import io.gravitee.gateway.reactive.api.context.GenericRequest;
+import io.gravitee.gateway.reactive.api.context.http.HttpBaseRequest;
 import java.util.Map;
 
 public class EvaluableRequest {
 
-    private final GenericRequest request;
+    private final HttpBaseRequest request;
     private String content;
     private Map<String, Object> jsonContent;
     private Map<String, Object> xmlContent;
 
-    public EvaluableRequest(final GenericRequest request) {
+    public EvaluableRequest(final HttpBaseRequest request) {
         this(request, null);
     }
 
-    public EvaluableRequest(final GenericRequest request, final String content) {
+    public EvaluableRequest(final HttpBaseRequest request, final String content) {
         this.request = request;
         this.content = content;
     }
@@ -118,7 +118,7 @@ public class EvaluableRequest {
     }
 
     public EvaluableSSLSession getSsl() {
-        return new EvaluableSSLSession(request.sslSession());
+        return new EvaluableSSLSession(request.tlsSession());
     }
 
     public void setContent(String content) {

--- a/src/main/java/io/gravitee/gateway/reactive/api/el/EvaluableResponse.java
+++ b/src/main/java/io/gravitee/gateway/reactive/api/el/EvaluableResponse.java
@@ -16,21 +16,21 @@
 package io.gravitee.gateway.reactive.api.el;
 
 import io.gravitee.gateway.api.http.HttpHeaders;
-import io.gravitee.gateway.reactive.api.context.GenericResponse;
+import io.gravitee.gateway.reactive.api.context.http.HttpBaseResponse;
 import java.util.Map;
 
 public class EvaluableResponse {
 
-    private final GenericResponse response;
+    private final HttpBaseResponse response;
     private String content;
     private Map<String, Object> jsonContent;
     private Map<String, Object> xmlContent;
 
-    public EvaluableResponse(final GenericResponse response) {
+    public EvaluableResponse(final HttpBaseResponse response) {
         this(response, null);
     }
 
-    public EvaluableResponse(final GenericResponse response, final String content) {
+    public EvaluableResponse(final HttpBaseResponse response, final String content) {
         this.response = response;
         this.content = content;
     }

--- a/src/main/java/io/gravitee/gateway/reactive/api/hook/Hook.java
+++ b/src/main/java/io/gravitee/gateway/reactive/api/hook/Hook.java
@@ -26,37 +26,8 @@ import io.reactivex.rxjava3.core.Completable;
  *
  * @author Guillaume LAMIRAND (guillaume.lamirand at graviteesource.com)
  * @author GraviteeSource Team
+ *
+ *  @deprecated see {@link HttpHook}
  */
-public interface Hook {
-    String id();
-
-    default Completable pre(final String id, final ExecutionContext ctx, @Nullable final ExecutionPhase executionPhase) {
-        return Completable.complete();
-    }
-
-    default Completable post(final String id, final ExecutionContext ctx, @Nullable final ExecutionPhase executionPhase) {
-        return Completable.complete();
-    }
-
-    default Completable error(
-        final String id,
-        final ExecutionContext ctx,
-        @Nullable final ExecutionPhase executionPhase,
-        final Throwable throwable
-    ) {
-        return Completable.complete();
-    }
-
-    default Completable interrupt(final String id, final ExecutionContext ctx, @Nullable final ExecutionPhase executionPhase) {
-        return Completable.complete();
-    }
-
-    default Completable interruptWith(
-        final String id,
-        final ExecutionContext ctx,
-        @Nullable final ExecutionPhase executionPhase,
-        final ExecutionFailure failure
-    ) {
-        return Completable.complete();
-    }
-}
+@Deprecated(forRemoval = true)
+public interface Hook extends HttpHook {}

--- a/src/main/java/io/gravitee/gateway/reactive/api/hook/HttpHook.java
+++ b/src/main/java/io/gravitee/gateway/reactive/api/hook/HttpHook.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gateway.reactive.api.hook;
+
+import io.gravitee.gateway.reactive.api.ExecutionFailure;
+import io.gravitee.gateway.reactive.api.ExecutionPhase;
+import io.gravitee.gateway.reactive.api.context.ExecutionContext;
+import io.gravitee.gateway.reactive.api.context.http.HttpExecutionContext;
+import io.reactivex.rxjava3.annotations.Nullable;
+import io.reactivex.rxjava3.core.Completable;
+
+/**
+ * Interface that can be used to add generic behaviour
+ *
+ * @author Guillaume LAMIRAND (guillaume.lamirand at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+public interface HttpHook {
+    String id();
+
+    default Completable pre(final String id, final HttpExecutionContext ctx, @Nullable final ExecutionPhase executionPhase) {
+        return Completable.complete();
+    }
+
+    default Completable post(final String id, final HttpExecutionContext ctx, @Nullable final ExecutionPhase executionPhase) {
+        return Completable.complete();
+    }
+
+    default Completable error(
+        final String id,
+        final HttpExecutionContext ctx,
+        @Nullable final ExecutionPhase executionPhase,
+        final Throwable throwable
+    ) {
+        return Completable.complete();
+    }
+
+    default Completable interrupt(final String id, final HttpExecutionContext ctx, @Nullable final ExecutionPhase executionPhase) {
+        return Completable.complete();
+    }
+
+    default Completable interruptWith(
+        final String id,
+        final HttpExecutionContext ctx,
+        @Nullable final ExecutionPhase executionPhase,
+        final ExecutionFailure failure
+    ) {
+        return Completable.complete();
+    }
+}

--- a/src/main/java/io/gravitee/gateway/reactive/api/hook/InvokerHook.java
+++ b/src/main/java/io/gravitee/gateway/reactive/api/hook/InvokerHook.java
@@ -19,4 +19,4 @@ package io.gravitee.gateway.reactive.api.hook;
  * @author Guillaume LAMIRAND (guillaume.lamirand at graviteesource.com)
  * @author GraviteeSource Team
  */
-public interface InvokerHook extends Hook {}
+public interface InvokerHook extends HttpHook {}

--- a/src/main/java/io/gravitee/gateway/reactive/api/hook/MessageHook.java
+++ b/src/main/java/io/gravitee/gateway/reactive/api/hook/MessageHook.java
@@ -21,4 +21,4 @@ package io.gravitee.gateway.reactive.api.hook;
  * @author Guillaume LAMIRAND (guillaume.lamirand at graviteesource.com)
  * @author GraviteeSource Team
  */
-public interface MessageHook extends Hook {}
+public interface MessageHook extends HttpHook {}

--- a/src/main/java/io/gravitee/gateway/reactive/api/hook/PolicyHook.java
+++ b/src/main/java/io/gravitee/gateway/reactive/api/hook/PolicyHook.java
@@ -21,4 +21,4 @@ package io.gravitee.gateway.reactive.api.hook;
  * @author Guillaume LAMIRAND (guillaume.lamirand at graviteesource.com)
  * @author GraviteeSource Team
  */
-public interface PolicyHook extends Hook {}
+public interface PolicyHook extends HttpHook {}

--- a/src/main/java/io/gravitee/gateway/reactive/api/hook/ProcessorHook.java
+++ b/src/main/java/io/gravitee/gateway/reactive/api/hook/ProcessorHook.java
@@ -21,4 +21,4 @@ package io.gravitee.gateway.reactive.api.hook;
  * @author Guillaume LAMIRAND (guillaume.lamirand at graviteesource.com)
  * @author GraviteeSource Team
  */
-public interface ProcessorHook extends Hook {}
+public interface ProcessorHook extends HttpHook {}

--- a/src/main/java/io/gravitee/gateway/reactive/api/hook/SecurityPlanHook.java
+++ b/src/main/java/io/gravitee/gateway/reactive/api/hook/SecurityPlanHook.java
@@ -21,4 +21,4 @@ package io.gravitee.gateway.reactive.api.hook;
  * @author Guillaume LAMIRAND (guillaume.lamirand at graviteesource.com)
  * @author GraviteeSource Team
  */
-public interface SecurityPlanHook extends Hook {}
+public interface SecurityPlanHook extends HttpHook {}

--- a/src/main/java/io/gravitee/gateway/reactive/api/policy/Policy.java
+++ b/src/main/java/io/gravitee/gateway/reactive/api/policy/Policy.java
@@ -17,6 +17,8 @@ package io.gravitee.gateway.reactive.api.policy;
 
 import io.gravitee.gateway.reactive.api.context.HttpExecutionContext;
 import io.gravitee.gateway.reactive.api.context.MessageExecutionContext;
+import io.gravitee.gateway.reactive.api.context.http.HttpMessageExecutionContext;
+import io.gravitee.gateway.reactive.api.context.http.HttpPlainExecutionContext;
 import io.gravitee.gateway.reactive.api.policy.http.HttpPolicy;
 import io.reactivex.rxjava3.core.Completable;
 
@@ -39,5 +41,21 @@ public interface Policy extends HttpPolicy {
 
     default Completable onMessageResponse(final MessageExecutionContext ctx) {
         return Completable.complete();
+    }
+
+    default Completable onRequest(final HttpPlainExecutionContext ctx) {
+        return onRequest((HttpExecutionContext) ctx);
+    }
+
+    default Completable onResponse(final HttpPlainExecutionContext ctx) {
+        return onResponse((HttpExecutionContext) ctx);
+    }
+
+    default Completable onMessageRequest(final HttpMessageExecutionContext ctx) {
+        return onMessageRequest((MessageExecutionContext) ctx);
+    }
+
+    default Completable onMessageResponse(final HttpMessageExecutionContext ctx) {
+        return onMessageResponse((MessageExecutionContext) ctx);
     }
 }

--- a/src/main/java/io/gravitee/gateway/reactive/api/policy/SecurityPolicy.java
+++ b/src/main/java/io/gravitee/gateway/reactive/api/policy/SecurityPolicy.java
@@ -16,8 +16,11 @@
 package io.gravitee.gateway.reactive.api.policy;
 
 import io.gravitee.gateway.reactive.api.context.HttpExecutionContext;
+import io.gravitee.gateway.reactive.api.context.MessageExecutionContext;
+import io.gravitee.gateway.reactive.api.context.http.HttpMessageExecutionContext;
 import io.gravitee.gateway.reactive.api.context.http.HttpPlainExecutionContext;
 import io.gravitee.gateway.reactive.api.policy.http.HttpSecurityPolicy;
+import io.reactivex.rxjava3.core.Completable;
 import io.reactivex.rxjava3.core.Maybe;
 
 /**
@@ -26,8 +29,28 @@ import io.reactivex.rxjava3.core.Maybe;
 @Deprecated(forRemoval = true)
 public interface SecurityPolicy extends HttpSecurityPolicy, Policy {
     default Maybe<SecurityToken> extractSecurityToken(HttpPlainExecutionContext ctx) {
-        return Maybe.empty();
+        return extractSecurityToken((HttpExecutionContext) ctx);
     }
 
     Maybe<SecurityToken> extractSecurityToken(final HttpExecutionContext ctx);
+
+    @Override
+    default Completable onResponse(final HttpExecutionContext ctx) {
+        return Policy.super.onResponse(ctx);
+    }
+
+    @Override
+    default Completable onResponse(final HttpPlainExecutionContext ctx) {
+        return HttpSecurityPolicy.super.onResponse(ctx);
+    }
+
+    @Override
+    default Completable onMessageResponse(final MessageExecutionContext ctx) {
+        return Policy.super.onMessageResponse(ctx);
+    }
+
+    @Override
+    default Completable onMessageResponse(final HttpMessageExecutionContext ctx) {
+        return HttpSecurityPolicy.super.onMessageResponse(ctx);
+    }
 }


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/APIM-7109

**Description**

Fix/complete the new HTTP-oriented interfaces to prepare for APIM to switch to the new interfaces internally.
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `3.9.0-apim-7109-switch-to-new-ctx-interfaces-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/gateway/gravitee-gateway-api/3.9.0-apim-7109-switch-to-new-ctx-interfaces-SNAPSHOT/gravitee-gateway-api-3.9.0-apim-7109-switch-to-new-ctx-interfaces-SNAPSHOT.zip)
  <!-- Version placeholder end -->
