### PR TITLE
fix: restore previous constructor as deprecated

### DIFF
--- a/src/main/java/io/gravitee/gateway/reactive/api/el/EvaluableRequest.java
+++ b/src/main/java/io/gravitee/gateway/reactive/api/el/EvaluableRequest.java
@@ -18,6 +18,7 @@ package io.gravitee.gateway.reactive.api.el;
 import io.gravitee.common.util.MultiValueMap;
 import io.gravitee.gateway.api.el.EvaluableSSLSession;
 import io.gravitee.gateway.api.http.HttpHeaders;
+import io.gravitee.gateway.reactive.api.context.GenericRequest;
 import io.gravitee.gateway.reactive.api.context.http.HttpBaseRequest;
 import java.util.Map;
 
@@ -27,6 +28,22 @@ public class EvaluableRequest {
     private String content;
     private Map<String, Object> jsonContent;
     private Map<String, Object> xmlContent;
+
+    /**
+     * @deprecated see {@link #EvaluableRequest(HttpBaseRequest)}
+     */
+    @Deprecated
+    public EvaluableRequest(final GenericRequest request) {
+        this(request, null);
+    }
+
+    /**
+     * @deprecated see {@link #EvaluableRequest(HttpBaseRequest, String)}
+     */
+    @Deprecated
+    public EvaluableRequest(final GenericRequest request, final String content) {
+        this((HttpBaseRequest) request, content);
+    }
 
     public EvaluableRequest(final HttpBaseRequest request) {
         this(request, null);

--- a/src/main/java/io/gravitee/gateway/reactive/api/el/EvaluableResponse.java
+++ b/src/main/java/io/gravitee/gateway/reactive/api/el/EvaluableResponse.java
@@ -16,6 +16,7 @@
 package io.gravitee.gateway.reactive.api.el;
 
 import io.gravitee.gateway.api.http.HttpHeaders;
+import io.gravitee.gateway.reactive.api.context.GenericResponse;
 import io.gravitee.gateway.reactive.api.context.http.HttpBaseResponse;
 import java.util.Map;
 
@@ -25,6 +26,22 @@ public class EvaluableResponse {
     private String content;
     private Map<String, Object> jsonContent;
     private Map<String, Object> xmlContent;
+
+    /**
+     * @deprecated see {@link #EvaluableResponse(HttpBaseResponse)}
+     */
+    @Deprecated
+    public EvaluableResponse(final GenericResponse response) {
+        this(response, null);
+    }
+
+    /**
+     * @deprecated see {@link #EvaluableResponse(HttpBaseResponse, String)}
+     */
+    @Deprecated
+    public EvaluableResponse(final GenericResponse response, final String content) {
+        this((HttpBaseResponse) response, content);
+    }
 
     public EvaluableResponse(final HttpBaseResponse response) {
         this(response, null);

--- a/src/test/java/io/gravitee/gateway/reactive/api/el/EvaluableRequestTest.java
+++ b/src/test/java/io/gravitee/gateway/reactive/api/el/EvaluableRequestTest.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gateway.reactive.api.el;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+
+import io.gravitee.gateway.reactive.api.context.GenericRequest;
+import io.gravitee.gateway.reactive.api.context.http.HttpBaseRequest;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+/**
+ * @author Jeoffrey HAEYAERT (jeoffrey.haeyaert at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+class EvaluableRequestTest {
+
+    @Test
+    void should_construct_with_http_base_request() {
+        HttpBaseRequest httpBaseRequest = Mockito.mock(HttpBaseRequest.class);
+        assertDoesNotThrow(() -> new EvaluableRequest(httpBaseRequest));
+    }
+
+    @Test
+    void should_construct_with_http_base_request_and_content() {
+        HttpBaseRequest httpBaseRequest = Mockito.mock(HttpBaseRequest.class);
+        assertDoesNotThrow(() -> new EvaluableRequest(httpBaseRequest, "content"));
+    }
+
+    @Test
+    void should_construct_with_generic_request() {
+        GenericRequest genericRequest = Mockito.mock(GenericRequest.class);
+        assertDoesNotThrow(() -> new EvaluableRequest(genericRequest));
+    }
+
+    @Test
+    void should_construct_with_generic_request_and_content() {
+        GenericRequest genericRequest = Mockito.mock(GenericRequest.class);
+        assertDoesNotThrow(() -> new EvaluableRequest(genericRequest, "content"));
+    }
+}

--- a/src/test/java/io/gravitee/gateway/reactive/api/el/EvaluableResponseTest.java
+++ b/src/test/java/io/gravitee/gateway/reactive/api/el/EvaluableResponseTest.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gateway.reactive.api.el;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+
+import io.gravitee.gateway.reactive.api.context.GenericResponse;
+import io.gravitee.gateway.reactive.api.context.http.HttpBaseResponse;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+/**
+ * @author Jeoffrey HAEYAERT (jeoffrey.haeyaert at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+class EvaluableResponseTest {
+
+    @Test
+    void should_construct_with_http_base_response() {
+        HttpBaseResponse httpBaseResponse = Mockito.mock(HttpBaseResponse.class);
+        assertDoesNotThrow(() -> new EvaluableResponse(httpBaseResponse));
+    }
+
+    @Test
+    void should_construct_with_http_base_response_and_content() {
+        HttpBaseResponse httpBaseResponse = Mockito.mock(HttpBaseResponse.class);
+        assertDoesNotThrow(() -> new EvaluableResponse(httpBaseResponse, "content"));
+    }
+
+    @Test
+    void should_construct_with_generic_response() {
+        GenericResponse genericResponse = Mockito.mock(GenericResponse.class);
+        assertDoesNotThrow(() -> new EvaluableResponse(genericResponse));
+    }
+
+    @Test
+    void should_construct_with_generic_response_and_content() {
+        GenericResponse genericResponse = Mockito.mock(GenericResponse.class);
+        assertDoesNotThrow(() -> new EvaluableResponse(genericResponse, "content"));
+    }
+}


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/APIM-7109

**Description**

Reintroduce and deprecate previous constructors so old policies can still be used before migrating to the new context interfaces.
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `3.9.0-fix-evaluable-request-response-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/gateway/gravitee-gateway-api/3.9.0-fix-evaluable-request-response-SNAPSHOT/gravitee-gateway-api-3.9.0-fix-evaluable-request-response-SNAPSHOT.zip)
  <!-- Version placeholder end -->
