### PR TITLE
Add elements to implement native security chain

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
 
     <groupId>io.gravitee.gateway</groupId>
     <artifactId>gravitee-gateway-api</artifactId>
-    <version>3.9.0-alpha.4</version>
+    <version>3.9.0-apim-7143-impl-security-chain-SNAPSHOT</version>
     <name>Gravitee.io APIM - Gateway - API</name>
 
     <properties>

--- a/src/main/java/io/gravitee/gateway/api/service/ApiKeyService.java
+++ b/src/main/java/io/gravitee/gateway/api/service/ApiKeyService.java
@@ -46,4 +46,13 @@ public interface ApiKeyService {
      * @return Found ApiKey
      */
     Optional<ApiKey> getByApiAndKey(String api, String key);
+
+    /**
+     * Get api key by its api and md5 hash of the key.
+     *
+     * @param api Searched api
+     * @param md5ApiKey Searched md5 hash of the key
+     * @return Found ApiKey
+     */
+    Optional<ApiKey> getByApiAndMd5Key(String api, String md5ApiKey);
 }

--- a/src/main/java/io/gravitee/gateway/reactive/api/context/base/BaseExecutionContext.java
+++ b/src/main/java/io/gravitee/gateway/reactive/api/context/base/BaseExecutionContext.java
@@ -177,4 +177,6 @@ public interface BaseExecutionContext {
      * @return the El {@link TemplateEngine}.
      */
     TemplateEngine getTemplateEngine();
+
+    long timestamp();
 }

--- a/src/main/java/io/gravitee/gateway/reactive/api/context/kafka/KafkaConnectionContext.java
+++ b/src/main/java/io/gravitee/gateway/reactive/api/context/kafka/KafkaConnectionContext.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gateway.reactive.api.context.kafka;
+
+import io.gravitee.gateway.reactive.api.context.base.NativeExecutionContext;
+import javax.security.auth.callback.Callback;
+
+/**
+ * Specialized context for Kafka connection.
+ *
+ * @author Jeoffrey HAEYAERT (jeoffrey.haeyaert at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+public interface KafkaConnectionContext extends NativeExecutionContext {
+    /**
+     * Access the array of {@link Callback} exchanged during connection. This can be used by a kafka security policy to extract a security token and to authenticate the connection.
+     * @return an array of {@link Callback}
+     */
+    Callback[] callbacks();
+
+    /**
+     * Access the SASL mechanism name used during connection. It can be 'PLAIN', 'SCRAM-SHA-256', 'SCRAM-SHA-512' or 'OAUTHBEARER'.
+     * @return the name of the SASL mechanism
+     */
+    String saslMechanism();
+}

--- a/src/main/java/io/gravitee/gateway/reactive/api/policy/SecurityToken.java
+++ b/src/main/java/io/gravitee/gateway/reactive/api/policy/SecurityToken.java
@@ -18,6 +18,7 @@ package io.gravitee.gateway.reactive.api.policy;
 import static io.gravitee.gateway.reactive.api.policy.SecurityToken.TokenType.API_KEY;
 import static io.gravitee.gateway.reactive.api.policy.SecurityToken.TokenType.CERTIFICATE;
 import static io.gravitee.gateway.reactive.api.policy.SecurityToken.TokenType.CLIENT_ID;
+import static io.gravitee.gateway.reactive.api.policy.SecurityToken.TokenType.MD5_API_KEY;
 import static io.gravitee.gateway.reactive.api.policy.SecurityToken.TokenType.NONE;
 
 import lombok.Builder;
@@ -32,6 +33,7 @@ public class SecurityToken {
     public enum TokenType {
         CLIENT_ID,
         API_KEY,
+        MD5_API_KEY,
         CERTIFICATE,
         NONE;
 
@@ -65,6 +67,15 @@ public class SecurityToken {
      */
     public static SecurityToken forApiKey(String apiKey) {
         return SecurityToken.builder().tokenType(API_KEY.name()).tokenValue(apiKey).build();
+    }
+
+    /**
+     * Creates an MD5 version of an API key based security token.
+     *
+     * @return security token
+     */
+    public static SecurityToken forMD5ApiKey(String md5ApiKey) {
+        return SecurityToken.builder().tokenType(MD5_API_KEY.name()).tokenValue(md5ApiKey).build();
     }
 
     /**

--- a/src/main/java/io/gravitee/gateway/reactive/api/policy/kafka/KafkaSecurityPolicy.java
+++ b/src/main/java/io/gravitee/gateway/reactive/api/policy/kafka/KafkaSecurityPolicy.java
@@ -15,21 +15,48 @@
  */
 package io.gravitee.gateway.reactive.api.policy.kafka;
 
+import io.gravitee.gateway.reactive.api.ExecutionPhase;
+import io.gravitee.gateway.reactive.api.context.kafka.KafkaConnectionContext;
 import io.gravitee.gateway.reactive.api.policy.SecurityToken;
 import io.gravitee.gateway.reactive.api.policy.base.BaseSecurityPolicy;
+import io.reactivex.rxjava3.core.Completable;
+import io.reactivex.rxjava3.core.Maybe;
 
 /**
  * {@link KafkaSecurityPolicy} is a {@link KafkaPolicy} that can be used for securing a plan that can require a subscription.
  * Implementing a {@link KafkaSecurityPolicy} requires to implement some additional behavior in order to be used by the gateway during the security chain execution that will identify which plan the consumer is using:
  * <ul>
  *     <li>{@link #order()}: to define the priority compared to other security policies</li>
- *     <li>TODO: extractSecurityToken: to extract the {@link SecurityToken} from the request execution context</li>
  *     <li>{@link #requireSubscription()} : to indicate if it require a valid subscription or not</li>
+ *     <li>{@link #extractSecurityToken(KafkaConnectionContext ctx)}: to extract the {@link SecurityToken} from the kafka connection context</li>
+ *     <li>{@link #authenticate(KafkaConnectionContext ctx)}: to validate the {@link SecurityToken} extracted from the kafka connection context</li>
  * </ul>
  *
  * @author Jeoffrey HAEYAERT (jeoffrey.haeyaert at graviteesource.com)
  * @author GraviteeSource Team
  */
 public interface KafkaSecurityPolicy extends KafkaPolicy, BaseSecurityPolicy {
-    /* TODO: To be define */
+    /**
+     * Extracts the {@link SecurityToken} from the kafka connection context.
+     * Relevant information is basically extracted from the array of {@link javax.security.auth.callback.Callback} available in the context.
+     * If no relevant {@link SecurityToken} is found, it returns an empty Maybe, so that policy won't be executed.
+     *
+     * @param ctx the current kafka connection context.
+     *
+     * @return the {@link SecurityToken} found in the kafka connection context
+     */
+    Maybe<SecurityToken> extractSecurityToken(final KafkaConnectionContext ctx);
+
+    /**
+     * Define the actions to perform during the connection.
+     * The <code>authenticate(KafkaConnectionContext)</code> method will be called during the connection between the kafka client and the gateway.
+     * In this method, the "Gravitee" security is checked before going further.
+     * For example, for an APIKey plan, the extracted apikey (extracted in the  <code>extractToken(KafkaConnectionContext)</code> method) is searched in the gateway cache.
+     * If the apikey is found and is valid, then the relevant {@link javax.security.auth.callback.Callback} has to be updated.
+     *
+     * @param ctx the current kafka connection context allowing to access the callbacks and the SASL mechanism used.
+     *
+     * @return a {@link Completable} that must complete when all the actions have been performed.
+     */
+    Completable authenticate(final KafkaConnectionContext ctx);
 }


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/APIM-7143

**Description**

- Add a new KafkaConnectionContext to be used to authenticate a connection
- Add required methods in the KafkaSecurityPolicy to be able to handle authentication
 
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `3.9.0-apim-7143-impl-security-chain-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/gateway/gravitee-gateway-api/3.9.0-apim-7143-impl-security-chain-SNAPSHOT/gravitee-gateway-api-3.9.0-apim-7143-impl-security-chain-SNAPSHOT.zip)
  <!-- Version placeholder end -->
