### PR TITLE
refactor: add abstract for DefaultMessage & KafkaMessage to manage at…

### DIFF
--- a/src/main/java/io/gravitee/gateway/reactive/api/message/AbstractMessage.java
+++ b/src/main/java/io/gravitee/gateway/reactive/api/message/AbstractMessage.java
@@ -1,0 +1,166 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gateway.reactive.api.message;
+
+import io.gravitee.common.util.ListUtils;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.experimental.SuperBuilder;
+
+@SuperBuilder
+@AllArgsConstructor
+@NoArgsConstructor
+public abstract class AbstractMessage implements Message {
+
+    public static final String SOURCE_TIMESTAMP = "sourceTimestamp";
+
+    @Builder.Default
+    protected long timestamp = System.currentTimeMillis();
+
+    @Getter(AccessLevel.NONE)
+    @Setter(AccessLevel.NONE)
+    protected long sourceTimestamp = timestamp;
+
+    protected Map<String, Object> metadata;
+    protected Map<String, Object> attributes;
+    protected Map<String, Object> internalAttributes;
+
+    @Override
+    public long timestamp() {
+        return this.timestamp;
+    }
+
+    @Override
+    public Map<String, Object> metadata() {
+        if (metadata == null) {
+            metadata = Map.of();
+        }
+        return metadata;
+    }
+
+    public AbstractMessage metadata(Map<String, Object> metadata) {
+        this.metadata = unmodifiableMetadata(metadata);
+        return this;
+    }
+
+    @Override
+    public <T> T attribute(String name) {
+        return (T) getOrInitAttribute().get(name);
+    }
+
+    @Override
+    public <T> List<T> attributeAsList(String name) {
+        return ListUtils.toList(getOrInitAttribute().get(name));
+    }
+
+    @Override
+    public Message attribute(String name, Object value) {
+        getOrInitAttribute().put(name, value);
+        return this;
+    }
+
+    @Override
+    public Message removeAttribute(String name) {
+        getOrInitAttribute().remove(name);
+        return this;
+    }
+
+    @Override
+    public Set<String> attributeNames() {
+        return getOrInitAttribute().keySet();
+    }
+
+    @Override
+    public <T> Map<String, T> attributes() {
+        return Collections.unmodifiableMap((Map<String, T>) getOrInitAttribute());
+    }
+
+    @Override
+    public <T> T internalAttribute(String name) {
+        return (T) getOrInitInternalAttribute().get(name);
+    }
+
+    @Override
+    public Message internalAttribute(String name, Object value) {
+        getOrInitInternalAttribute().put(name, value);
+        return this;
+    }
+
+    @Override
+    public Message removeInternalAttribute(String name) {
+        getOrInitInternalAttribute().remove(name);
+        return this;
+    }
+
+    @Override
+    public Set<String> internalAttributeNames() {
+        return getOrInitInternalAttribute().keySet();
+    }
+
+    @Override
+    public <T> Map<String, T> internalAttributes() {
+        return Collections.unmodifiableMap((Map<String, T>) getOrInitInternalAttribute());
+    }
+
+    private Map<String, Object> getOrInitAttribute() {
+        if (this.attributes == null) {
+            this.attributes = new HashMap<>();
+        }
+        return this.attributes;
+    }
+
+    private Map<String, Object> getOrInitInternalAttribute() {
+        if (this.internalAttributes == null) {
+            this.internalAttributes = new HashMap<>();
+        }
+        return this.internalAttributes;
+    }
+
+    protected static Map<String, Object> unmodifiableMetadata(final Map<String, Object> metadata) {
+        if (metadata != null) {
+            return Collections.unmodifiableMap(metadata);
+        } else {
+            return Map.of();
+        }
+    }
+
+    public abstract static class AbstractMessageBuilder<C extends AbstractMessage, B extends AbstractMessage.AbstractMessageBuilder<C, B>> {
+
+        // Insert sourceTimestamp into metadata before building the object
+        B prebuild() {
+            if (!timestamp$set) {
+                timestamp(System.currentTimeMillis());
+            }
+            if (metadata == null) {
+                metadata = new HashMap<>();
+            }
+            if (!metadata.containsKey(SOURCE_TIMESTAMP)) {
+                metadata.put(SOURCE_TIMESTAMP, sourceTimestamp != 0L ? sourceTimestamp : timestamp$value);
+            }
+            metadata = unmodifiableMetadata(metadata);
+            return self();
+        }
+    }
+}

--- a/src/main/java/io/gravitee/gateway/reactive/api/message/DefaultMessage.java
+++ b/src/main/java/io/gravitee/gateway/reactive/api/message/DefaultMessage.java
@@ -15,33 +15,26 @@
  */
 package io.gravitee.gateway.reactive.api.message;
 
-import io.gravitee.common.util.ListUtils;
 import io.gravitee.gateway.api.buffer.Buffer;
 import io.gravitee.gateway.api.http.HttpHeaders;
 import io.gravitee.gateway.reactive.api.tracing.message.TracingMessage;
-import java.util.Collections;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import java.util.UUID;
-import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
-import lombok.Getter;
 import lombok.NoArgsConstructor;
-import lombok.Setter;
 import lombok.experimental.Accessors;
+import lombok.experimental.SuperBuilder;
 
 @Data
-@Builder
+@SuperBuilder
 @AllArgsConstructor
 @NoArgsConstructor
 @Accessors(fluent = true)
-public class DefaultMessage implements TracingMessage {
+public class DefaultMessage extends AbstractMessage implements TracingMessage {
 
-    public static final String SOURCE_TIMESTAMP = "sourceTimestamp";
     private String id;
 
     @Builder.Default
@@ -49,16 +42,6 @@ public class DefaultMessage implements TracingMessage {
 
     private String parentCorrelationId;
 
-    @Builder.Default
-    private long timestamp = System.currentTimeMillis();
-
-    @Getter(AccessLevel.NONE)
-    @Setter(AccessLevel.NONE)
-    private long sourceTimestamp = timestamp;
-
-    private Map<String, Object> attributes;
-    private Map<String, Object> internalAttributes;
-    private Map<String, Object> metadata;
     private HttpHeaders headers;
     private Buffer content;
     private boolean error;
@@ -72,81 +55,6 @@ public class DefaultMessage implements TracingMessage {
         if (content != null) {
             this.content = Buffer.buffer(content);
         }
-    }
-
-    private static Map<String, Object> unmodifiableMetadata(final Map<String, Object> metadata) {
-        if (metadata != null) {
-            return Collections.unmodifiableMap(metadata);
-        } else {
-            return Map.of();
-        }
-    }
-
-    @Override
-    public <T> T attribute(final String name) {
-        return (T) getOrInitAttribute().get(name);
-    }
-
-    @Override
-    public <T> List<T> attributeAsList(String name) {
-        return ListUtils.toList(getOrInitAttribute().get(name));
-    }
-
-    @Override
-    public DefaultMessage attribute(final String name, final Object value) {
-        getOrInitAttribute().put(name, value);
-        return this;
-    }
-
-    @Override
-    public DefaultMessage removeAttribute(final String name) {
-        getOrInitAttribute().remove(name);
-        return this;
-    }
-
-    @Override
-    public Set<String> attributeNames() {
-        return getOrInitAttribute().keySet();
-    }
-
-    @Override
-    public <T> Map<String, T> attributes() {
-        return Collections.unmodifiableMap((Map<String, T>) getOrInitAttribute());
-    }
-
-    @Override
-    public <T> T internalAttribute(final String name) {
-        return (T) getOrInitInternalAttribute().get(name);
-    }
-
-    @Override
-    public DefaultMessage internalAttribute(final String name, final Object value) {
-        getOrInitInternalAttribute().put(name, value);
-        return this;
-    }
-
-    @Override
-    public DefaultMessage removeInternalAttribute(final String name) {
-        getOrInitInternalAttribute().remove(name);
-        return this;
-    }
-
-    @Override
-    public Set<String> internalAttributeNames() {
-        return getOrInitInternalAttribute().keySet();
-    }
-
-    @Override
-    public <T> Map<String, T> internalAttributes() {
-        return Collections.unmodifiableMap((Map<String, T>) getOrInitInternalAttribute());
-    }
-
-    @Override
-    public Map<String, Object> metadata() {
-        if (metadata == null) {
-            metadata = Map.of();
-        }
-        return metadata;
     }
 
     @Override
@@ -171,11 +79,6 @@ public class DefaultMessage implements TracingMessage {
             this.content((Buffer) null);
         }
 
-        return this;
-    }
-
-    public DefaultMessage metadata(Map<String, Object> metadata) {
-        this.metadata = unmodifiableMetadata(metadata);
         return this;
     }
 
@@ -219,44 +122,15 @@ public class DefaultMessage implements TracingMessage {
         tracingAttributes.put(key, value);
     }
 
-    public static DefaultMessageBuilder builder() {
-        return new DefaultMessageBuilder() {
+    private static class DefaultMessageBuilderImpl extends DefaultMessageBuilder<DefaultMessage, DefaultMessageBuilderImpl> {}
+
+    public static DefaultMessage.DefaultMessageBuilder<?, ?> builder() {
+        return new DefaultMessage.DefaultMessageBuilderImpl() {
             @Override
             public DefaultMessage build() {
                 prebuild();
                 return super.build();
             }
         };
-    }
-
-    public static class DefaultMessageBuilder {
-
-        // Insert sourceTimestamp into metadata before building the object
-        void prebuild() {
-            if (!timestamp$set) {
-                timestamp(System.currentTimeMillis());
-            }
-            if (metadata == null) {
-                metadata = new HashMap<>();
-            }
-            if (!metadata.containsKey(SOURCE_TIMESTAMP)) {
-                metadata.put(SOURCE_TIMESTAMP, sourceTimestamp != 0L ? sourceTimestamp : timestamp$value);
-            }
-            metadata = unmodifiableMetadata(metadata);
-        }
-    }
-
-    private Map<String, Object> getOrInitAttribute() {
-        if (this.attributes == null) {
-            this.attributes = new HashMap<>();
-        }
-        return this.attributes;
-    }
-
-    private Map<String, Object> getOrInitInternalAttribute() {
-        if (this.internalAttributes == null) {
-            this.internalAttributes = new HashMap<>();
-        }
-        return this.internalAttributes;
     }
 }

--- a/src/test/java/io/gravitee/gateway/reactive/api/message/DefaultMessageTest.java
+++ b/src/test/java/io/gravitee/gateway/reactive/api/message/DefaultMessageTest.java
@@ -48,15 +48,6 @@ class DefaultMessageTest {
     }
 
     @Test
-    void shouldReturnUnmodifiableMetadataMapWithSetter() {
-        Map<String, Object> metadata = new HashMap<>();
-        metadata.put("key", INTERNAL_ATTR_VALUE);
-        DefaultMessage cut = DefaultMessage.builder().build();
-        cut.metadata(metadata);
-        assertThrows(java.lang.UnsupportedOperationException.class, () -> cut.metadata().put(INTERNAL_ATTR_TEST, INTERNAL_ATTR_TEST));
-    }
-
-    @Test
     void shouldPutAttribute() {
         DefaultMessage cut = DefaultMessage.builder().build();
         assertNull(cut.attribute(ATTR_TEST));
@@ -135,14 +126,8 @@ class DefaultMessageTest {
     }
 
     @Test
-    void shouldHaveCorrelationIdFromEmptyConstructor() {
-        DefaultMessage cut = new DefaultMessage();
-        assertNotNull(cut.correlationId());
-    }
-
-    @Test
     void shouldHaveCorrelationIdFromBufferConstructor() {
-        DefaultMessage cut = new DefaultMessage((String) null);
+        DefaultMessage cut = DefaultMessage.builder().content(BUFFER).build();
         assertNotNull(cut.correlationId());
     }
 

--- a/src/test/java/io/gravitee/gateway/reactive/api/message/DefaultMessageTest.java
+++ b/src/test/java/io/gravitee/gateway/reactive/api/message/DefaultMessageTest.java
@@ -142,7 +142,7 @@ class DefaultMessageTest {
 
     @Test
     void shouldHaveCorrelationIdFromBufferConstructor() {
-        DefaultMessage cut = new DefaultMessage(null);
+        DefaultMessage cut = new DefaultMessage((String) null);
         assertNotNull(cut.correlationId());
     }
 


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/APIM-7304

**Description**

Add abstract for DefaultMessage & KafkaMessage to manage attributes & internalAttributes & metadata

**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `3.9.0-APIM-7304-abstract-message-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/gateway/gravitee-gateway-api/3.9.0-APIM-7304-abstract-message-SNAPSHOT/gravitee-gateway-api-3.9.0-APIM-7304-abstract-message-SNAPSHOT.zip)
  <!-- Version placeholder end -->
