### PR TITLE
feat: add kafka as listener type

### DIFF
--- a/src/main/java/io/gravitee/gateway/reactive/api/ListenerType.java
+++ b/src/main/java/io/gravitee/gateway/reactive/api/ListenerType.java
@@ -29,9 +29,19 @@ import lombok.RequiredArgsConstructor;
 public enum ListenerType {
     HTTP("http"),
     SUBSCRIPTION("subscription"),
-    TCP("tcp");
+    TCP("tcp"),
+    KAFKA("kafka");
 
-    private static final Map<String, ListenerType> LABELS_MAP = Map.of(HTTP.label, HTTP, SUBSCRIPTION.label, SUBSCRIPTION, TCP.label, TCP);
+    private static final Map<String, ListenerType> LABELS_MAP = Map.of(
+        HTTP.label,
+        HTTP,
+        SUBSCRIPTION.label,
+        SUBSCRIPTION,
+        TCP.label,
+        TCP,
+        KAFKA.label,
+        KAFKA
+    );
 
     @JsonValue
     private final String label;


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/issues/issues/XXXXX

**Description**

Add `KAFKA` as a possible enum for `ListenerType`.

**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `3.9.0-apim-7152-add-kafka-listener-type-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/gateway/gravitee-gateway-api/3.9.0-apim-7152-add-kafka-listener-type-SNAPSHOT/gravitee-gateway-api-3.9.0-apim-7152-add-kafka-listener-type-SNAPSHOT.zip)
  <!-- Version placeholder end -->
