### PR TITLE
feat: add connect + interact as connector modes

### DIFF
--- a/src/main/java/io/gravitee/gateway/reactive/api/ConnectorMode.java
+++ b/src/main/java/io/gravitee/gateway/reactive/api/ConnectorMode.java
@@ -30,7 +30,9 @@ public enum ConnectorMode {
     SUBSCRIBE("subscribe"),
     PUBLISH("publish"),
     REQUEST_RESPONSE("request_response"),
-    SOCKET("socket");
+    SOCKET("socket"),
+    INTERACT("interact"),
+    CONNECT("connect");
 
     private static final Map<String, ConnectorMode> LABELS_MAP = Map.of(
         SUBSCRIBE.label,
@@ -40,7 +42,11 @@ public enum ConnectorMode {
         REQUEST_RESPONSE.label,
         REQUEST_RESPONSE,
         SOCKET.label,
-        SOCKET
+        SOCKET,
+        INTERACT.label,
+        INTERACT,
+        CONNECT.label,
+        CONNECT
     );
 
     @JsonValue


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/issues/issues/XXXXX

**Description**

Add `connect` and `interact` to `ConnectorMode` enum.

**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `3.9.0-apim-7152-add-native-connector-modes-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/gateway/gravitee-gateway-api/3.9.0-apim-7152-add-native-connector-modes-SNAPSHOT/gravitee-gateway-api-3.9.0-apim-7152-add-native-connector-modes-SNAPSHOT.zip)
  <!-- Version placeholder end -->
