### PR TITLE
feat: add native to api type enum

### DIFF
--- a/src/main/java/io/gravitee/gateway/reactive/api/ApiType.java
+++ b/src/main/java/io/gravitee/gateway/reactive/api/ApiType.java
@@ -28,9 +28,10 @@ import lombok.RequiredArgsConstructor;
 @Getter
 public enum ApiType {
     PROXY("proxy"),
-    MESSAGE("message");
+    MESSAGE("message"),
+    NATIVE("native");
 
-    private static final Map<String, ApiType> LABELS_MAP = Map.of(PROXY.label, PROXY, MESSAGE.label, MESSAGE);
+    private static final Map<String, ApiType> LABELS_MAP = Map.of(PROXY.label, PROXY, MESSAGE.label, MESSAGE, NATIVE.label, NATIVE);
 
     @JsonValue
     private final String label;


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/issues/issues/XXXXX

**Description**

Add `NATIVE` to `ApiType` enum.

**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `3.9.0-apim-7152-add-native-api-type-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/gateway/gravitee-gateway-api/3.9.0-apim-7152-add-native-api-type-SNAPSHOT/gravitee-gateway-api-3.9.0-apim-7152-add-native-api-type-SNAPSHOT.zip)
  <!-- Version placeholder end -->
