### PR TITLE
feat: access KafkaPrincipal from KafkaContext

### DIFF
--- a/src/main/java/io/gravitee/gateway/reactive/api/context/kafka/KafkaConnectionContext.java
+++ b/src/main/java/io/gravitee/gateway/reactive/api/context/kafka/KafkaConnectionContext.java
@@ -17,6 +17,7 @@ package io.gravitee.gateway.reactive.api.context.kafka;
 
 import io.gravitee.gateway.reactive.api.context.base.NativeExecutionContext;
 import javax.security.auth.callback.Callback;
+import org.apache.kafka.common.security.auth.KafkaPrincipal;
 
 /**
  * Specialized context for Kafka connection.
@@ -36,4 +37,10 @@ public interface KafkaConnectionContext extends NativeExecutionContext {
      * @return the name of the SASL mechanism
      */
     String saslMechanism();
+
+    /**
+     * Access the principal of the current connection.
+     * @return the principal of the current connection.
+     */
+    KafkaPrincipal principal();
 }

--- a/src/main/java/io/gravitee/gateway/reactive/api/context/kafka/KafkaExecutionContext.java
+++ b/src/main/java/io/gravitee/gateway/reactive/api/context/kafka/KafkaExecutionContext.java
@@ -18,6 +18,7 @@ package io.gravitee.gateway.reactive.api.context.kafka;
 import io.gravitee.gateway.reactive.api.context.base.NativeExecutionContext;
 import org.apache.kafka.common.protocol.ApiKeys;
 import org.apache.kafka.common.requests.AbstractResponse;
+import org.apache.kafka.common.security.auth.KafkaPrincipal;
 
 /**
  * Execution context specialized for Kafka.
@@ -30,4 +31,10 @@ public interface KafkaExecutionContext extends NativeExecutionContext {
     int correlationId();
     KafkaRequest request();
     KafkaResponse response();
+
+    /**
+     * Access the principal of the current execution context.
+     * @return the principal of the current execution context.
+     */
+    KafkaPrincipal principal();
 }

--- a/src/main/java/io/gravitee/gateway/reactive/api/context/kafka/KafkaMessageExecutionContext.java
+++ b/src/main/java/io/gravitee/gateway/reactive/api/context/kafka/KafkaMessageExecutionContext.java
@@ -16,6 +16,7 @@
 package io.gravitee.gateway.reactive.api.context.kafka;
 
 import io.gravitee.gateway.reactive.api.context.base.NativeMessageExecutionContext;
+import org.apache.kafka.common.security.auth.KafkaPrincipal;
 
 /**
  * Message execution context specialized for Kafka.
@@ -32,7 +33,13 @@ public interface KafkaMessageExecutionContext extends NativeMessageExecutionCont
 
     /**
      * Get the current response attached to this execution context when it is available.
-     * @return a Single that will emit the KafkaMessageResponse when available.
+     * @return the response.
      */
     KafkaMessageResponse response();
+
+    /**
+     * Access the principal of the current execution context.
+     * @return the principal of the current execution context.
+     */
+    KafkaPrincipal principal();
 }


### PR DESCRIPTION
**Issue**

N/A

**Description**

access KafkaPrincipal from Kafka contexts
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `3.9.0-handle-principal-in-kafka-context-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/gateway/gravitee-gateway-api/3.9.0-handle-principal-in-kafka-context-SNAPSHOT/gravitee-gateway-api-3.9.0-handle-principal-in-kafka-context-SNAPSHOT.zip)
  <!-- Version placeholder end -->
