### PR TITLE
fix: init tracing attributes if necessary when adding new attributes

### DIFF
--- a/src/main/java/io/gravitee/gateway/reactive/api/message/DefaultMessage.java
+++ b/src/main/java/io/gravitee/gateway/reactive/api/message/DefaultMessage.java
@@ -129,6 +129,9 @@ public class DefaultMessage extends AbstractMessage implements TracingMessage {
         if (key == null || value == null) {
             throw new IllegalArgumentException("Key or value of tracing attribute cannot be null");
         }
+        if (this.tracingAttributes == null) {
+            this.tracingAttributes = new HashMap<>();
+        }
         tracingAttributes.put(key, value);
     }
 


### PR DESCRIPTION
**Description**

In some cases where external component wants to add tracing attributes, the map could be null. This PR attempts to fix it.

**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `3.9.0-fix-init-tracing-attributes-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/gateway/gravitee-gateway-api/3.9.0-fix-init-tracing-attributes-SNAPSHOT/gravitee-gateway-api-3.9.0-fix-init-tracing-attributes-SNAPSHOT.zip)
  <!-- Version placeholder end -->
