### PR TITLE
feat: access to NetworkController in KafkaExecutionContext

### DIFF
--- a/src/main/java/io/gravitee/gateway/reactive/api/context/kafka/KafkaExecutionContext.java
+++ b/src/main/java/io/gravitee/gateway/reactive/api/context/kafka/KafkaExecutionContext.java
@@ -17,7 +17,6 @@ package io.gravitee.gateway.reactive.api.context.kafka;
 
 import io.gravitee.gateway.reactive.api.context.base.NativeExecutionContext;
 import org.apache.kafka.common.protocol.ApiKeys;
-import org.apache.kafka.common.requests.AbstractResponse;
 import org.apache.kafka.common.security.auth.KafkaPrincipal;
 
 /**
@@ -37,4 +36,10 @@ public interface KafkaExecutionContext extends NativeExecutionContext {
      * @return the principal of the current execution context.
      */
     KafkaPrincipal principal();
+
+    /**
+     * Access the network controller of the current execution context.
+     * @return the network controller of the current execution context.
+     */
+    NetworkController networkController();
 }

--- a/src/main/java/io/gravitee/gateway/reactive/api/context/kafka/KafkaExecutionContext.java
+++ b/src/main/java/io/gravitee/gateway/reactive/api/context/kafka/KafkaExecutionContext.java
@@ -16,6 +16,10 @@
 package io.gravitee.gateway.reactive.api.context.kafka;
 
 import io.gravitee.gateway.reactive.api.context.base.NativeExecutionContext;
+import io.reactivex.rxjava3.core.Completable;
+import java.util.List;
+import java.util.function.Function;
+import javax.annotation.Nullable;
 import org.apache.kafka.common.protocol.ApiKeys;
 import org.apache.kafka.common.security.auth.KafkaPrincipal;
 
@@ -42,4 +46,17 @@ public interface KafkaExecutionContext extends NativeExecutionContext {
      * @return the network controller of the current execution context.
      */
     NetworkController networkController();
+
+    /**
+     * Allows defining an action in the request phase to be executed at the response phase.
+     * @param onResponseCallback the action to be executed at the response phase.
+     */
+    void addActionOnResponse(Function<KafkaExecutionContext, Completable> onResponseCallback);
+
+    /**
+     * Get the list of actions to be executed at the response phase.
+     * @return a list of actions to be executed at the response phase.
+     */
+    @Nullable
+    List<Function<KafkaExecutionContext, Completable>> getOnResponseActions();
 }

--- a/src/main/java/io/gravitee/gateway/reactive/api/context/kafka/KafkaRequest.java
+++ b/src/main/java/io/gravitee/gateway/reactive/api/context/kafka/KafkaRequest.java
@@ -30,4 +30,9 @@ public interface KafkaRequest extends NativeRequest {
      * @return the Kafka native request.
      */
     <T extends AbstractRequest> T delegate();
+
+    /**
+     * Register that the request has been updated during its processing and need to be rebuilt before sending it.
+     */
+    void notifyChange();
 }

--- a/src/main/java/io/gravitee/gateway/reactive/api/context/kafka/KafkaResponse.java
+++ b/src/main/java/io/gravitee/gateway/reactive/api/context/kafka/KafkaResponse.java
@@ -30,4 +30,9 @@ public interface KafkaResponse extends NativeResponse {
      * @return the Kafka native response.
      */
     <T extends AbstractResponse> T delegate();
+
+    /**
+     * Register that the response has been updated during its processing and need to be rebuilt before sending it.
+     */
+    void notifyChange();
 }

--- a/src/main/java/io/gravitee/gateway/reactive/api/context/kafka/NetworkController.java
+++ b/src/main/java/io/gravitee/gateway/reactive/api/context/kafka/NetworkController.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gateway.reactive.api.context.kafka;
+
+import java.time.Duration;
+
+public interface NetworkController {
+    /**
+     * Pauses the acceptance of incoming data for the specified duration.
+     * The flow is resumed once the duration is over or an explicit call to {@link #resume()} is performed.
+     *
+     * @param duration the duration to apply before calling resume.
+     */
+    void pause(Duration duration);
+
+    /**
+     * Immediately resume the flow of incoming data.
+     */
+    void resume();
+}


### PR DESCRIPTION
**Description**

A FlowController interface is added to KafkaExecutionContext. It can be used from inside a Policy to stop/resume the acceptance of new requests. It has been introduced for Kafka Quota Policy to handle throttling: when we detect the quota limit has been reached, the GW will stop accepting requests until the throttling time has passed.

A new method, `addActionOnResponse`, has been added to `KafkaExecutionContext` to register a callback that must be applied on the response. This allows to work on the response inside `onRequest` method of a policy.

`notifyChange` method was declared in an internal interface, but when a policy updates the request and/or response, we need to call it from inside the policy to ensure the request/response is rebuilt.

**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `3.9.0-flowcontrol-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/gateway/gravitee-gateway-api/3.9.0-flowcontrol-SNAPSHOT/gravitee-gateway-api-3.9.0-flowcontrol-SNAPSHOT.zip)
  <!-- Version placeholder end -->
