### PR TITLE
fix: remove getOnResponseActions from KafkaExecutionContext

### DIFF
--- a/src/main/java/io/gravitee/gateway/reactive/api/context/kafka/KafkaExecutionContext.java
+++ b/src/main/java/io/gravitee/gateway/reactive/api/context/kafka/KafkaExecutionContext.java
@@ -17,9 +17,7 @@ package io.gravitee.gateway.reactive.api.context.kafka;
 
 import io.gravitee.gateway.reactive.api.context.base.NativeExecutionContext;
 import io.reactivex.rxjava3.core.Completable;
-import java.util.List;
 import java.util.function.Function;
-import javax.annotation.Nullable;
 import org.apache.kafka.common.protocol.ApiKeys;
 import org.apache.kafka.common.security.auth.KafkaPrincipal;
 
@@ -52,11 +50,4 @@ public interface KafkaExecutionContext extends NativeExecutionContext {
      * @param onResponseCallback the action to be executed at the response phase.
      */
     void addActionOnResponse(Function<KafkaExecutionContext, Completable> onResponseCallback);
-
-    /**
-     * Get the list of actions to be executed at the response phase.
-     * @return a list of actions to be executed at the response phase.
-     */
-    @Nullable
-    List<Function<KafkaExecutionContext, Completable>> getOnResponseActions();
 }


### PR DESCRIPTION
**Description**

This method should not be callable from Policy's code. It needs to be moved in the internal interface.


**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `3.9.0-remove-method-from-kafka-execution-context-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/gateway/gravitee-gateway-api/3.9.0-remove-method-from-kafka-execution-context-SNAPSHOT/gravitee-gateway-api-3.9.0-remove-method-from-kafka-execution-context-SNAPSHOT.zip)
  <!-- Version placeholder end -->
