### PR TITLE
feat: add TemplateEngine for native Kafka

### DIFF
--- a/src/main/java/io/gravitee/gateway/reactive/api/context/kafka/KafkaExecutionContext.java
+++ b/src/main/java/io/gravitee/gateway/reactive/api/context/kafka/KafkaExecutionContext.java
@@ -28,6 +28,10 @@ import org.apache.kafka.common.security.auth.KafkaPrincipal;
  * @author GraviteeSource Team
  */
 public interface KafkaExecutionContext extends NativeExecutionContext {
+    String TEMPLATE_ATTRIBUTE_REQUEST = "request";
+    String TEMPLATE_ATTRIBUTE_RESPONSE = "response";
+    String TEMPLATE_ATTRIBUTE_CONTEXT = "context";
+
     ApiKeys apiKey();
     int correlationId();
     KafkaRequest request();

--- a/src/main/java/io/gravitee/gateway/reactive/api/context/kafka/KafkaMessageExecutionContext.java
+++ b/src/main/java/io/gravitee/gateway/reactive/api/context/kafka/KafkaMessageExecutionContext.java
@@ -15,7 +15,9 @@
  */
 package io.gravitee.gateway.reactive.api.context.kafka;
 
+import io.gravitee.el.TemplateEngine;
 import io.gravitee.gateway.reactive.api.context.base.NativeMessageExecutionContext;
+import io.gravitee.gateway.reactive.api.message.kafka.KafkaMessage;
 import org.apache.kafka.common.security.auth.KafkaPrincipal;
 
 /**
@@ -25,6 +27,8 @@ import org.apache.kafka.common.security.auth.KafkaPrincipal;
  * @author GraviteeSource Team
  */
 public interface KafkaMessageExecutionContext extends NativeMessageExecutionContext {
+    String TEMPLATE_ATTRIBUTE_MESSAGE = "message";
+
     /**
      * Get the current request attached to this execution context.
      * @return the request.
@@ -42,4 +46,12 @@ public interface KafkaMessageExecutionContext extends NativeMessageExecutionCont
      * @return the principal of the current execution context.
      */
     KafkaPrincipal principal();
+
+    /**
+     * Get the {@link TemplateEngine} that can be used to evaluate EL expressions.
+     *
+     * @param message the message to evaluate.
+     * @return the El {@link TemplateEngine}.
+     */
+    TemplateEngine getTemplateEngine(KafkaMessage message);
 }


### PR DESCRIPTION
**Issue**
https://gravitee.atlassian.net/browse/APIM-7139

**Description**

add TemplateEngine for native Kafka

? i'm wonder if we can use the `BaseMessageExecutionContext` to extends `NativeMessageExecutionContext` but i'm not sure about interruptMessages stuff. maybe we can see it later when we know how to interrupt messages 

**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `3.9.0-APIM-7139-TemplateEngine-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/gateway/gravitee-gateway-api/3.9.0-APIM-7139-TemplateEngine-SNAPSHOT/gravitee-gateway-api-3.9.0-APIM-7139-TemplateEngine-SNAPSHOT.zip)
  <!-- Version placeholder end -->
