### PR TITLE
feat: add TemplateEngine for KafkaConnectionContext

### DIFF
--- a/src/main/java/io/gravitee/gateway/reactive/api/context/base/BaseExecutionContext.java
+++ b/src/main/java/io/gravitee/gateway/reactive/api/context/base/BaseExecutionContext.java
@@ -32,6 +32,7 @@ import javax.net.ssl.SSLSession;
  * @author GraviteeSource Team
  */
 public interface BaseExecutionContext {
+    String TEMPLATE_ATTRIBUTE_CONTEXT = "context";
     /**
      * Get the metrics associated to the context.
      *

--- a/src/main/java/io/gravitee/gateway/reactive/api/context/http/HttpPlainExecutionContext.java
+++ b/src/main/java/io/gravitee/gateway/reactive/api/context/http/HttpPlainExecutionContext.java
@@ -29,7 +29,6 @@ import io.reactivex.rxjava3.core.Maybe;
 public interface HttpPlainExecutionContext extends HttpBaseExecutionContext {
     String TEMPLATE_ATTRIBUTE_REQUEST = "request";
     String TEMPLATE_ATTRIBUTE_RESPONSE = "response";
-    String TEMPLATE_ATTRIBUTE_CONTEXT = "context";
 
     /**
      * Get the current request stuck to this execution context.

--- a/src/main/java/io/gravitee/gateway/reactive/api/context/kafka/KafkaExecutionContext.java
+++ b/src/main/java/io/gravitee/gateway/reactive/api/context/kafka/KafkaExecutionContext.java
@@ -30,7 +30,6 @@ import org.apache.kafka.common.security.auth.KafkaPrincipal;
 public interface KafkaExecutionContext extends NativeExecutionContext {
     String TEMPLATE_ATTRIBUTE_REQUEST = "request";
     String TEMPLATE_ATTRIBUTE_RESPONSE = "response";
-    String TEMPLATE_ATTRIBUTE_CONTEXT = "context";
 
     ApiKeys apiKey();
     int correlationId();


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/APIM-7719

**Description**

Juste add String used by this PR https://github.com/gravitee-io/gravitee-reactor-native-kafka/pull/41

Similar to KafkaExecutionContext but for Connection

**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `3.9.0-APIM-7719-template-engine-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/gateway/gravitee-gateway-api/3.9.0-APIM-7719-template-engine-SNAPSHOT/gravitee-gateway-api-3.9.0-APIM-7719-template-engine-SNAPSHOT.zip)
  <!-- Version placeholder end -->
