### PR TITLE
feat: add interact in ConnectorMode

### DIFF
--- a/src/main/java/io/gravitee/gateway/reactive/api/ConnectorMode.java
+++ b/src/main/java/io/gravitee/gateway/reactive/api/ConnectorMode.java
@@ -27,12 +27,18 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 @Getter
 public enum ConnectorMode {
+    CONNECT("connect"),
+    INTERACT("interact"),
     SUBSCRIBE("subscribe"),
     PUBLISH("publish"),
     REQUEST_RESPONSE("request_response"),
     SOCKET("socket");
 
     private static final Map<String, ConnectorMode> LABELS_MAP = Map.of(
+        CONNECT.label,
+        CONNECT,
+        INTERACT.label,
+        INTERACT,
         SUBSCRIBE.label,
         SUBSCRIBE,
         PUBLISH.label,


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/APIM-7165

**Description**

Add `interact` to configure it on kafka endpoints and entrypoints. which will allow the PolicyStudio phases to be compatible with

I hesitate to add `connect` immediately WDYT? 

**Additional context**


Then update APIM then update connector-native-kafka then APIM again 

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `3.9.0-APIM-7162-interact-connectorMode-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/gateway/gravitee-gateway-api/3.9.0-APIM-7162-interact-connectorMode-SNAPSHOT/gravitee-gateway-api-3.9.0-APIM-7162-interact-connectorMode-SNAPSHOT.zip)
  <!-- Version placeholder end -->
