### PR TITLE
Kafka: add interruptWith with KafkaExecutionFailure

### DIFF
--- a/src/main/java/io/gravitee/gateway/reactive/api/context/kafka/KafkaExecutionContext.java
+++ b/src/main/java/io/gravitee/gateway/reactive/api/context/kafka/KafkaExecutionContext.java
@@ -16,6 +16,7 @@
 package io.gravitee.gateway.reactive.api.context.kafka;
 
 import io.gravitee.gateway.reactive.api.context.base.NativeExecutionContext;
+import io.gravitee.gateway.reactive.api.exception.kafka.KafkaExecutionFailure;
 import io.reactivex.rxjava3.core.Completable;
 import java.util.function.Function;
 import org.apache.kafka.common.protocol.ApiKeys;
@@ -53,4 +54,10 @@ public interface KafkaExecutionContext extends NativeExecutionContext {
      * @param onResponseCallback the action to be executed at the response phase.
      */
     void addActionOnResponse(Function<KafkaExecutionContext, Completable> onResponseCallback);
+
+    /**
+     * Interrupts the current execution while indicating that the response can be sent "as is" to the downstream.
+     * @param failure {@link KafkaExecutionFailure} object that indicates that the execution has failed.
+     */
+    Completable interruptWith(final KafkaExecutionFailure failure);
 }

--- a/src/main/java/io/gravitee/gateway/reactive/api/exception/base/BaseExecutionFailure.java
+++ b/src/main/java/io/gravitee/gateway/reactive/api/exception/base/BaseExecutionFailure.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gateway.reactive.api.exception.base;
+
+public interface BaseExecutionFailure {
+    String message();
+}

--- a/src/main/java/io/gravitee/gateway/reactive/api/exception/base/NativeExecutionFailure.java
+++ b/src/main/java/io/gravitee/gateway/reactive/api/exception/base/NativeExecutionFailure.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gateway.reactive.api.exception.base;
+
+public interface NativeExecutionFailure extends BaseExecutionFailure {}

--- a/src/main/java/io/gravitee/gateway/reactive/api/exception/kafka/KafkaExecutionFailure.java
+++ b/src/main/java/io/gravitee/gateway/reactive/api/exception/kafka/KafkaExecutionFailure.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gateway.reactive.api.exception.kafka;
+
+import io.gravitee.gateway.reactive.api.exception.base.NativeExecutionFailure;
+import org.apache.kafka.common.protocol.Errors;
+
+public interface KafkaExecutionFailure extends NativeExecutionFailure {
+    Errors errors();
+}


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/APIM-7533

**Description**

add interruptWith with KafkaExecutionFailure

Uses the same structure as for context. but the refactoring with the "HTTP part" will have to be done later

**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `3.9.0-APIM-7533-interruptionWith-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/gateway/gravitee-gateway-api/3.9.0-APIM-7533-interruptionWith-SNAPSHOT/gravitee-gateway-api-3.9.0-APIM-7533-interruptionWith-SNAPSHOT.zip)
  <!-- Version placeholder end -->
