### PR TITLE
feat: access to Kafka connection context from execution context

### DIFF
--- a/src/main/java/io/gravitee/gateway/reactive/api/context/kafka/KafkaExecutionContext.java
+++ b/src/main/java/io/gravitee/gateway/reactive/api/context/kafka/KafkaExecutionContext.java
@@ -38,6 +38,12 @@ public interface KafkaExecutionContext extends NativeExecutionContext {
     KafkaResponse response();
 
     /**
+     * Access the connection context.
+     * @return the connection context.
+     */
+    KafkaConnectionContext connectionContext();
+
+    /**
      * Access the principal of the current execution context.
      * @return the principal of the current execution context.
      */


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/issues/issues/APIM-7136

**Description**

Access to Kafka connection context from execution context

**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `3.9.0-apim7136-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/gateway/gravitee-gateway-api/3.9.0-apim7136-SNAPSHOT/gravitee-gateway-api-3.9.0-apim7136-SNAPSHOT.zip)
  <!-- Version placeholder end -->
