### PR TITLE
fix: access Kafka execution context from KafkaMessageExecutionContext

### DIFF
--- a/src/main/java/io/gravitee/gateway/reactive/api/context/kafka/KafkaMessageExecutionContext.java
+++ b/src/main/java/io/gravitee/gateway/reactive/api/context/kafka/KafkaMessageExecutionContext.java
@@ -30,6 +30,12 @@ public interface KafkaMessageExecutionContext extends NativeMessageExecutionCont
     String TEMPLATE_ATTRIBUTE_MESSAGE = "message";
 
     /**
+     * Access the execution context.
+     * @return the execution context.
+     */
+    KafkaExecutionContext executionContext();
+
+    /**
      * Get the current request attached to this execution context.
      * @return the request.
      */


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/issues/issues/APIM-8108

**Description**

Access to KafkaExecution Context from KafkaMessageExecutionContext

**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `3.9.1-apim8108-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/gateway/gravitee-gateway-api/3.9.1-apim8108-SNAPSHOT/gravitee-gateway-api-3.9.1-apim8108-SNAPSHOT.zip)
  <!-- Version placeholder end -->
