### PR TITLE
Add TopicIdentity concept capable of initialising itself before executing a any policy chain

### DIFF
--- a/src/main/java/io/gravitee/gateway/reactive/api/context/kafka/KafkaConnectionContext.java
+++ b/src/main/java/io/gravitee/gateway/reactive/api/context/kafka/KafkaConnectionContext.java
@@ -47,8 +47,8 @@ public interface KafkaConnectionContext extends NativeExecutionContext {
 
     /**
      * Access the registry of topic identities.
-     * This registry store any Kafka topics (by there name & Uuid) from the broker (source=BROKER). But also those which could
-     * be created by our policy ( e.g. TopicMappingPolicy ) and used by clients (source=CLIENT).
+     * This registry store any Kafka topics (by their name & Uuid) from the broker (source=BROKER). But also those which could
+     * be created by our policies ( e.g. TopicMappingPolicy ) and used by clients (source=CLIENT).
      * The registry can be used to find the name of a topic from an id or vice versa.
      * @return {@link TopicIdentityRegistry}
      */

--- a/src/main/java/io/gravitee/gateway/reactive/api/context/kafka/KafkaConnectionContext.java
+++ b/src/main/java/io/gravitee/gateway/reactive/api/context/kafka/KafkaConnectionContext.java
@@ -16,6 +16,7 @@
 package io.gravitee.gateway.reactive.api.context.kafka;
 
 import io.gravitee.gateway.reactive.api.context.base.NativeExecutionContext;
+import io.gravitee.gateway.reactive.api.context.kafka.topicidentity.TopicIdentityRegistry;
 import javax.security.auth.callback.Callback;
 import org.apache.kafka.common.security.auth.KafkaPrincipal;
 
@@ -43,4 +44,13 @@ public interface KafkaConnectionContext extends NativeExecutionContext {
      * @return the principal of the current connection.
      */
     KafkaPrincipal principal();
+
+    /**
+     * Access the registry of topic identities.
+     * This registry store any Kafka topics (by there name & Uuid) from the broker (source=BROKER). But also those which could
+     * be created by our policy ( e.g. TopicMappingPolicy ) and used by clients (source=CLIENT).
+     * The registry can be used to find the name of a topic from an id or vice versa.
+     * @return {@link TopicIdentityRegistry}
+     */
+    TopicIdentityRegistry topicIdentityRegistry();
 }

--- a/src/main/java/io/gravitee/gateway/reactive/api/context/kafka/topicidentity/TopicIdentity.java
+++ b/src/main/java/io/gravitee/gateway/reactive/api/context/kafka/topicidentity/TopicIdentity.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gateway.reactive.api.context.kafka.topicidentity;
+
+import org.apache.kafka.common.Uuid;
+
+public record TopicIdentity(Uuid id, String name, Source source) {
+    public enum Source {
+        BROKER,
+        CLIENT,
+    }
+}

--- a/src/main/java/io/gravitee/gateway/reactive/api/context/kafka/topicidentity/TopicIdentityRegistry.java
+++ b/src/main/java/io/gravitee/gateway/reactive/api/context/kafka/topicidentity/TopicIdentityRegistry.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gateway.reactive.api.context.kafka.topicidentity;
+
+import java.util.Optional;
+import org.apache.kafka.common.Uuid;
+
+public interface TopicIdentityRegistry {
+    /**
+     * Find a topic identity by its name
+     * @param name the name of the topic.
+     * @return Optional of {@link TopicIdentity}
+     */
+    Optional<TopicIdentity> findByName(String name);
+
+    /**
+     * Find a topic identity by its id
+     * @param id Uuid of the topic.
+     * @return Optional of {@link TopicIdentity}.
+     */
+    Optional<TopicIdentity> findById(Uuid id);
+
+    /**
+     * Put a topic identity in the registry
+     * @param topicIdentity {@link TopicIdentity}
+     */
+    void put(TopicIdentity topicIdentity);
+}

--- a/src/main/java/io/gravitee/gateway/reactive/api/policy/kafka/KafkaPolicy.java
+++ b/src/main/java/io/gravitee/gateway/reactive/api/policy/kafka/KafkaPolicy.java
@@ -16,6 +16,7 @@
 package io.gravitee.gateway.reactive.api.policy.kafka;
 
 import io.gravitee.gateway.reactive.api.ExecutionPhase;
+import io.gravitee.gateway.reactive.api.context.kafka.KafkaConnectionContext;
 import io.gravitee.gateway.reactive.api.context.kafka.KafkaExecutionContext;
 import io.gravitee.gateway.reactive.api.context.kafka.KafkaMessageExecutionContext;
 import io.gravitee.gateway.reactive.api.policy.base.BasePolicy;
@@ -37,6 +38,17 @@ import io.reactivex.rxjava3.core.Completable;
  * @author GraviteeSource Team
  */
 public interface KafkaPolicy extends BasePolicy {
+    /**
+     * Define the actions to perform once api is deployed and the connection is established.
+     * The <code>onInitialize(KafkaConnectionContext)</code> method will be called once before any policy chain construction.
+     *
+     * @param ctx the current connection context allowing to access the connection attributes & topicIdentityRegistry.
+     * @return a {@link Completable} that must complete when all the actions have been performed.
+     */
+    default Completable onInitialize(final KafkaConnectionContext ctx) {
+        return Completable.complete();
+    }
+
     /**
      * Define the actions to perform during the {@link ExecutionPhase#REQUEST} phase.
      * The <code>onRequest(KafkaExecutionContext)</code> method will be called during the policy chain construction.


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/APIM-8332
https://gravitee.atlassian.net/browse/APIM-8335

**Description**
Add interface for kafka TopicIdentityRegistry
Add onInitialize to KafkaPolicy

**Additional context**

Expected for 4.6.x and next 4.7.x 

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `3.10.0-APIM-8332-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/gateway/gravitee-gateway-api/3.10.0-APIM-8332-SNAPSHOT/gravitee-gateway-api-3.10.0-APIM-8332-SNAPSHOT.zip)
  <!-- Version placeholder end -->
