### PR TITLE
Bump dependencies

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ version: 2.1
 setup: true
 
 orbs:
-    gravitee: gravitee-io/gravitee@4.8.0
+    gravitee: gravitee-io/gravitee@4.12.1
 
 # our single workflow, that triggers the setup job defined above, filters on tag and branches are needed otherwise
 # some workflow and job will not be triggered for tags (default CircleCI behavior)

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,11 +1,4 @@
 {
-    "extends": ["config:base", "schedule:earlyMondays"],
-    "prConcurrentLimit": 3,
-    "rebaseWhen": "conflicted",
-    "packageRules": [
-        {
-            "matchDatasources": ["orb"],
-            "rangeStrategy": "replace"
-        }
-    ]
+    "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+    "extends": ["local>gravitee-io/renovate-config:lib"]
 }

--- a/pom.xml
+++ b/pom.xml
@@ -35,7 +35,7 @@
     <properties>
         <gravitee-bom.version>8.2.10</gravitee-bom.version>
         <gravitee-node.version>7.0.7</gravitee-node.version>
-        <gravitee-common.version>4.5.1</gravitee-common.version>
+        <gravitee-common.version>4.6.0</gravitee-common.version>
         <gravitee-policy-api.version>1.11.0</gravitee-policy-api.version>
         <gravitee-reporter-api.version>1.31.2</gravitee-reporter-api.version>
         <gravitee-expression-language.version>3.2.1</gravitee-expression-language.version>

--- a/pom.xml
+++ b/pom.xml
@@ -42,7 +42,7 @@
         <gravitee-apim-gateway-buffer.version>3.19.0</gravitee-apim-gateway-buffer.version>
 
         <bouncycastle.version>1.78.1</bouncycastle.version>
-        <json-smart.version>2.4.10</json-smart.version>
+        <json-smart.version>2.5.2</json-smart.version>
         <kafka-clients.version>3.7.1</kafka-clients.version>
     </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -34,7 +34,7 @@
 
     <properties>
         <gravitee-bom.version>8.2.10</gravitee-bom.version>
-        <gravitee-node.version>7.0.0</gravitee-node.version>
+        <gravitee-node.version>7.0.7</gravitee-node.version>
         <gravitee-common.version>4.5.1</gravitee-common.version>
         <gravitee-policy-api.version>1.11.0</gravitee-policy-api.version>
         <gravitee-reporter-api.version>1.31.2</gravitee-reporter-api.version>

--- a/pom.xml
+++ b/pom.xml
@@ -41,7 +41,7 @@
         <gravitee-expression-language.version>3.2.1</gravitee-expression-language.version>
         <gravitee-apim-gateway-buffer.version>3.19.0</gravitee-apim-gateway-buffer.version>
 
-        <bouncycastle.version>1.70</bouncycastle.version>
+        <bouncycastle.version>1.78.1</bouncycastle.version>
         <json-smart.version>2.4.10</json-smart.version>
         <kafka-clients.version>3.7.1</kafka-clients.version>
     </properties>
@@ -109,7 +109,7 @@
         </dependency>
         <dependency>
             <groupId>org.bouncycastle</groupId>
-            <artifactId>bcpkix-jdk15on</artifactId>
+            <artifactId>bcpkix-jdk18on</artifactId>
             <version>${bouncycastle.version}</version>
             <scope>provided</scope>
         </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.gravitee</groupId>
         <artifactId>gravitee-parent</artifactId>
-        <version>22.0.4</version>
+        <version>22.2.5</version>
     </parent>
 
     <groupId>io.gravitee.gateway</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@
     <name>Gravitee.io APIM - Gateway - API</name>
 
     <properties>
-        <gravitee-bom.version>8.2.9</gravitee-bom.version>
+        <gravitee-bom.version>8.2.10</gravitee-bom.version>
         <gravitee-node.version>7.0.0</gravitee-node.version>
         <gravitee-common.version>4.5.1</gravitee-common.version>
         <gravitee-policy-api.version>1.11.0</gravitee-policy-api.version>


### PR DESCRIPTION
**Description**

Bump dependencies.
Especially the `json-smart` one to fix a vulnerability in APIM

**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `3.11.1-bump-dependencies-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/gateway/gravitee-gateway-api/3.11.1-bump-dependencies-SNAPSHOT/gravitee-gateway-api-3.11.1-bump-dependencies-SNAPSHOT.zip)
  <!-- Version placeholder end -->
