### PR TITLE
feat(kafka): add key setter methods to KafkaMessage interface

### DIFF
--- a/src/main/java/io/gravitee/gateway/reactive/api/message/kafka/KafkaMessage.java
+++ b/src/main/java/io/gravitee/gateway/reactive/api/message/kafka/KafkaMessage.java
@@ -52,6 +52,23 @@ public interface KafkaMessage extends Message {
     Buffer key();
 
     /**
+     * Set the Kafka record key associated with the message.
+     * Allows modification of the Kafka key.
+     *
+     * @param key the buffer representing the Kafka key
+     * @return reference to itself for easily chain calls.
+     */
+    KafkaMessage key(final Buffer key);
+
+    /**
+     * Overloaded setter for the Kafka key accepting a String.
+     *
+     * @param key the string representing the Kafka key
+     * @return reference to itself for easily chain calls.
+     */
+    KafkaMessage key(final String key);
+
+    /**
      * Get the Kafka record offset value associated to the message.
      * @return the Kafka offset
      */


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/APIM-8989

**Description**

Add key setter methods to KafkaMessage interface.

**Note:** Do we need an overloaded setter for the Kafka key accepting a String ???

**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `3.12.0-APIM-8989-add-key-setter-methods-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/gateway/gravitee-gateway-api/3.12.0-APIM-8989-add-key-setter-methods-SNAPSHOT/gravitee-gateway-api-3.12.0-APIM-8989-add-key-setter-methods-SNAPSHOT.zip)
  <!-- Version placeholder end -->
