### PR TITLE
feat: move metrics to HttpBaseExecutionContext

### DIFF
--- a/src/main/java/io/gravitee/gateway/reactive/api/context/base/BaseExecutionContext.java
+++ b/src/main/java/io/gravitee/gateway/reactive/api/context/base/BaseExecutionContext.java
@@ -18,7 +18,6 @@ package io.gravitee.gateway.reactive.api.context.base;
 import io.gravitee.el.TemplateEngine;
 import io.gravitee.gateway.reactive.api.context.TlsSession;
 import io.gravitee.gateway.reactive.api.tracing.Tracer;
-import io.gravitee.reporter.api.v4.metric.Metrics;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -33,12 +32,6 @@ import javax.net.ssl.SSLSession;
  */
 public interface BaseExecutionContext {
     String TEMPLATE_ATTRIBUTE_CONTEXT = "context";
-    /**
-     * Get the metrics associated to the context.
-     *
-     * @return a {@link Metrics} object.
-     */
-    Metrics metrics();
 
     <T> T getComponent(Class<T> componentClass);
 

--- a/src/main/java/io/gravitee/gateway/reactive/api/context/http/HttpBaseExecutionContext.java
+++ b/src/main/java/io/gravitee/gateway/reactive/api/context/http/HttpBaseExecutionContext.java
@@ -16,6 +16,7 @@
 package io.gravitee.gateway.reactive.api.context.http;
 
 import io.gravitee.gateway.reactive.api.context.base.BaseExecutionContext;
+import io.gravitee.reporter.api.v4.metric.Metrics;
 
 /**
  * Base interface any http-based execution context interface can inherit from.
@@ -24,6 +25,13 @@ import io.gravitee.gateway.reactive.api.context.base.BaseExecutionContext;
  *  @author GraviteeSource Team
  */
 public interface HttpBaseExecutionContext extends BaseExecutionContext {
+    /**
+     * Get the metrics associated with the context.
+     *
+     * @return a {@link Metrics} object.
+     */
+    Metrics metrics();
+
     /**
      * Get the current request stuck to this execution context.
      *


### PR DESCRIPTION
**Issue**

related to https://gravitee.atlassian.net/browse/APIM-7779 

**Description**

because Metrics obj is dedicated to Http and cannot be used for the Native concept

**Please review this:** 

After discussion with Jeoffrey we will make a breaking changes for this change.

**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `4.0.0-move-metrics-to-http-context-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/gateway/gravitee-gateway-api/4.0.0-move-metrics-to-http-context-SNAPSHOT/gravitee-gateway-api-4.0.0-move-metrics-to-http-context-SNAPSHOT.zip)
  <!-- Version placeholder end -->
