### PR TITLE
feat: allow to get the size of the message in bytes

### DIFF
--- a/src/main/java/io/gravitee/gateway/reactive/api/message/kafka/KafkaMessage.java
+++ b/src/main/java/io/gravitee/gateway/reactive/api/message/kafka/KafkaMessage.java
@@ -92,6 +92,12 @@ public interface KafkaMessage extends Message {
      */
     String topic();
 
+    /**
+     * Get the size in bytes of that message.
+     * @return the size in bytes
+     */
+    int sizeInBytes();
+
     @Deprecated
     default void ack() {
         throw new IllegalStateException("Ack not supported for Kafka messages");


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/APIM-10270

**Description**

Allow to get the size of the message in bytes
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `3.13.0-offload-record-instead-of-content-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/gateway/gravitee-gateway-api/3.13.0-offload-record-instead-of-content-SNAPSHOT/gravitee-gateway-api-3.13.0-offload-record-instead-of-content-SNAPSHOT.zip)
  <!-- Version placeholder end -->
