### PR TITLE
feat: add llm-proxy api type

### DIFF
--- a/src/main/java/io/gravitee/gateway/reactive/api/ApiType.java
+++ b/src/main/java/io/gravitee/gateway/reactive/api/ApiType.java
@@ -28,6 +28,7 @@ import lombok.RequiredArgsConstructor;
 @Getter
 public enum ApiType {
     LLM_PROXY("llm-proxy"),
+    MCP_PROXY("mcp-proxy"),
     PROXY("proxy"),
     MESSAGE("message"),
     NATIVE("native");
@@ -35,6 +36,8 @@ public enum ApiType {
     private static final Map<String, ApiType> LABELS_MAP = Map.of(
         LLM_PROXY.label,
         LLM_PROXY,
+        MCP_PROXY.label,
+        MCP_PROXY,
         PROXY.label,
         PROXY,
         MESSAGE.label,

--- a/src/main/java/io/gravitee/gateway/reactive/api/ApiType.java
+++ b/src/main/java/io/gravitee/gateway/reactive/api/ApiType.java
@@ -27,11 +27,21 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 @Getter
 public enum ApiType {
+    LLM_PROXY("llm-proxy"),
     PROXY("proxy"),
     MESSAGE("message"),
     NATIVE("native");
 
-    private static final Map<String, ApiType> LABELS_MAP = Map.of(PROXY.label, PROXY, MESSAGE.label, MESSAGE, NATIVE.label, NATIVE);
+    private static final Map<String, ApiType> LABELS_MAP = Map.of(
+        LLM_PROXY.label,
+        LLM_PROXY,
+        PROXY.label,
+        PROXY,
+        MESSAGE.label,
+        MESSAGE,
+        NATIVE.label,
+        NATIVE
+    );
 
     @JsonValue
     private final String label;


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/issues/issues/XXXXX

**Description**

Add LLM & MCP API types.

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `4.1.0-llm-proxy-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/gateway/gravitee-gateway-api/4.1.0-llm-proxy-SNAPSHOT/gravitee-gateway-api-4.1.0-llm-proxy-SNAPSHOT.zip)
  <!-- Version placeholder end -->
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `4.1.0-llm-proxy-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/gateway/gravitee-gateway-api/4.1.0-llm-proxy-SNAPSHOT/gravitee-gateway-api-4.1.0-llm-proxy-SNAPSHOT.zip)
  <!-- Version placeholder end -->
