### PR TITLE
feat: add the request original url attribute key

### DIFF
--- a/src/main/java/io/gravitee/gateway/reactive/api/context/ContextAttributes.java
+++ b/src/main/java/io/gravitee/gateway/reactive/api/context/ContextAttributes.java
@@ -37,6 +37,7 @@ public final class ContextAttributes {
     public static final String ATTR_REQUEST_ENDPOINT = ATTR_PREFIX + "request.endpoint";
     public static final String ATTR_REQUEST_ENDPOINT_OVERRIDE = ATTR_PREFIX + "request.endpoint.override";
     public static final String ATTR_REQUEST_METHOD = ATTR_PREFIX + "request.method";
+    public static final String ATTR_REQUEST_ORIGINAL_URL = ATTR_PREFIX + "request.original-url";
     public static final String ATTR_PLAN = ATTR_PREFIX + "plan";
     public static final String ATTR_SUBSCRIPTION_ID = ATTR_PREFIX + "user-id";
     public static final String ATTR_API_DEPLOYED_AT = ATTR_PREFIX + "api.deployed-at";


### PR DESCRIPTION

<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `4.2.0-add-original-url-attribute-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/gateway/gravitee-gateway-api/4.2.0-add-original-url-attribute-SNAPSHOT/gravitee-gateway-api-4.2.0-add-original-url-attribute-SNAPSHOT.zip)
  <!-- Version placeholder end -->
