### PR TITLE
chore: add @gravitee-io/tech-lead to CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
 # Default
-*       @gravitee-io/apim @gravitee-io/archi
+*       @gravitee-io/apim @gravitee-io/archi @gravitee-io/tech-lead


### PR DESCRIPTION
## Summary
- Add `@gravitee-io/tech-lead` team as code owners alongside `@gravitee-io/archi` for the entire repository

## Changes
The CODEOWNERS file is updated to include `@gravitee-io/tech-lead` on the `*` pattern, ensuring that members of the tech-lead team are automatically requested for review on all pull requests.
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `5.1.1`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/gateway/gravitee-gateway-api/5.1.1/gravitee-gateway-api-5.1.1.zip)
  <!-- Version placeholder end -->
