### PR TITLE
fix: add Private Network Access header constants (APIM-13215)

### DIFF
--- a/src/main/java/io/gravitee/gateway/api/http/HttpHeaderNames.java
+++ b/src/main/java/io/gravitee/gateway/api/http/HttpHeaderNames.java
@@ -74,6 +74,14 @@ public interface HttpHeaderNames {
      */
     public static final String ACCESS_CONTROL_REQUEST_METHOD = "Access-Control-Request-Method";
     /**
+     * See {@link <a href="https://wicg.github.io/private-network-access/#headers">Private Network Access specification</a>}.
+     */
+    public static final String ACCESS_CONTROL_REQUEST_PRIVATE_NETWORK = "Access-Control-Request-Private-Network";
+    /**
+     * See {@link <a href="https://wicg.github.io/private-network-access/#headers">Private Network Access specification</a>}.
+     */
+    public static final String ACCESS_CONTROL_ALLOW_PRIVATE_NETWORK = "Access-Control-Allow-Private-Network";
+    /**
      * See {@link <a href="https://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.6">HTTP/1.1 documentation</a>}.
      */
     public static final String AGE = "Age";


### PR DESCRIPTION
## Summary
- Add `ACCESS_CONTROL_REQUEST_PRIVATE_NETWORK` and `ACCESS_CONTROL_ALLOW_PRIVATE_NETWORK` constants to `HttpHeaderNames`
- See [WICG Private Network Access specification](https://wicg.github.io/private-network-access/#headers)
- Required by APIM to support Private Network Access (PNA) in CORS preflight handling

## Test plan
- [x] Constants are compile-time only, no runtime behavior change
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `5.1.1-fix-resolve-APIM-13215-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/gateway/gravitee-gateway-api/5.1.1-fix-resolve-APIM-13215-SNAPSHOT/gravitee-gateway-api-5.1.1-fix-resolve-APIM-13215-SNAPSHOT.zip)
  <!-- Version placeholder end -->
