### PR TITLE
feat: add register body change for HTTP request and response

### DIFF
--- a/src/main/java/io/gravitee/gateway/reactive/api/context/http/HttpPlainRequest.java
+++ b/src/main/java/io/gravitee/gateway/reactive/api/context/http/HttpPlainRequest.java
@@ -19,6 +19,7 @@ import io.gravitee.common.http.HttpMethod;
 import io.gravitee.gateway.api.buffer.Buffer;
 import io.gravitee.gateway.reactive.api.ws.WebSocket;
 import io.reactivex.rxjava3.core.*;
+import java.util.function.Consumer;
 
 /**
  * Represents a request that can manipulate a plain http body (as a single buffer or a flow of chunks).
@@ -200,4 +201,12 @@ public interface HttpPlainRequest extends HttpBaseRequest {
     void contentLength(long length);
 
     void method(HttpMethod method);
+
+    /**
+     * Registers a listener that will be notified when the body content changes.
+     * This can happen when the body is set imperatively or when a body transformation completes.
+     *
+     * @param listener the callback to invoke with the new body buffer.
+     */
+    default void registerBodyChangeListener(Consumer<Buffer> listener) {}
 }

--- a/src/main/java/io/gravitee/gateway/reactive/api/context/http/HttpPlainResponse.java
+++ b/src/main/java/io/gravitee/gateway/reactive/api/context/http/HttpPlainResponse.java
@@ -17,6 +17,7 @@ package io.gravitee.gateway.reactive.api.context.http;
 
 import io.gravitee.gateway.api.buffer.Buffer;
 import io.reactivex.rxjava3.core.*;
+import java.util.function.Consumer;
 
 /**
  * Represents a response that can manipulate a plain http body (as a single buffer or a flow of chunks).
@@ -153,4 +154,12 @@ public interface HttpPlainResponse extends HttpBaseResponse {
      * @param length The value of the `Content-Length` header
      */
     void contentLength(long length);
+
+    /**
+     * Registers a listener that will be notified when the body content changes.
+     * This can happen when the body is set imperatively or when a body transformation completes.
+     *
+     * @param listener the callback to invoke with the new body buffer.
+     */
+    default void registerBodyChangeListener(Consumer<Buffer> listener) {}
 }

--- a/src/main/java/io/gravitee/gateway/reactive/api/context/llm/LlmRequestInspector.java
+++ b/src/main/java/io/gravitee/gateway/reactive/api/context/llm/LlmRequestInspector.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gateway.reactive.api.context.llm;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import io.gravitee.gateway.api.buffer.Buffer;
+import io.gravitee.gateway.reactive.api.context.http.HttpExecutionContext;
+import io.reactivex.rxjava3.core.Maybe;
+import org.jspecify.annotations.Nullable;
+
+public interface LlmRequestInspector {
+    KindSemantic kind(HttpExecutionContext context, JsonNode body);
+
+    Maybe<String> prompt(@Nullable Buffer buffer, HttpExecutionContext context, PromptQuery promptQuery);
+
+    sealed interface PromptQuery {
+        record LastUserPrompt() implements PromptQuery {}
+
+        record AllUserPrompts() implements PromptQuery {}
+
+        record AllPrompts() implements PromptQuery {}
+
+        record CustomPrompt(String expressionLanguage) implements PromptQuery {}
+    }
+
+    enum KindSemantic {
+        PROMPT,
+        TOOL_CALL,
+        TOOL_RESULT,
+        ERROR,
+    }
+}


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/GMA-128

**Description**

linked to:

- https://github.com/gravitee-io/gravitee-reactor-llm-proxy/pull/111
- https://github.com/gravitee-io/gravitee-api-management/pull/16568


---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `6.0.0-mba-gma-128-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/gateway/gravitee-gateway-api/6.0.0-mba-gma-128-SNAPSHOT/gravitee-gateway-api-6.0.0-mba-gma-128-SNAPSHOT.zip)
  <!-- Version placeholder end -->
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `6.0.0-mba-gma-128-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/gateway/gravitee-gateway-api/6.0.0-mba-gma-128-SNAPSHOT/gravitee-gateway-api-6.0.0-mba-gma-128-SNAPSHOT.zip)
  <!-- Version placeholder end -->
