### PR TITLE
feat(APIM-13619): expose traceId() and spanId() on gateway Tracer

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -34,10 +34,10 @@
 
     <properties>
         <gravitee-bom.version>9.0.0-alpha.2</gravitee-bom.version>
-        <gravitee-node.version>9.0.0-alpha.1</gravitee-node.version>
+        <gravitee-node.version>9.0.0-alpha.10</gravitee-node.version>
         <gravitee-common.version>4.9.0</gravitee-common.version>
         <gravitee-policy-api.version>1.11.0</gravitee-policy-api.version>
-        <gravitee-reporter-api.version>1.31.2</gravitee-reporter-api.version>
+        <gravitee-reporter-api.version>2.3.0</gravitee-reporter-api.version>
         <gravitee-expression-language.version>3.2.1</gravitee-expression-language.version>
 
         <bouncycastle.version>1.80</bouncycastle.version>

--- a/src/main/java/io/gravitee/gateway/reactive/api/tracing/Tracer.java
+++ b/src/main/java/io/gravitee/gateway/reactive/api/tracing/Tracer.java
@@ -73,4 +73,12 @@ public class Tracer {
     public <C> void injectSpanContext(final Span span, final BiConsumer<String, String> textMapSetter) {
         delegate.injectSpanContext(vertxContext, span, textMapSetter);
     }
+
+    public String traceId() {
+        return delegate.traceId(vertxContext);
+    }
+
+    public String spanId() {
+        return delegate.spanId(vertxContext);
+    }
 }


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/APIM-13619

**Description**

Extends the tracing.Tracer wrapper with traceId() and spanId() methods that delegate to the underlying OTel span context.
Allows gateway components to read the current trace/span IDs.

**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `6.0.0-feat-APIM-13619-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/gateway/gravitee-gateway-api/6.0.0-feat-APIM-13619-SNAPSHOT/gravitee-gateway-api-6.0.0-feat-APIM-13619-SNAPSHOT.zip)
  <!-- Version placeholder end -->
