### PR TITLE
fix: use HttpBaseExecutionContext for API of LlmRequestInspector

### DIFF
--- a/src/main/java/io/gravitee/gateway/reactive/api/context/llm/LlmRequestInspector.java
+++ b/src/main/java/io/gravitee/gateway/reactive/api/context/llm/LlmRequestInspector.java
@@ -17,14 +17,14 @@ package io.gravitee.gateway.reactive.api.context.llm;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import io.gravitee.gateway.api.buffer.Buffer;
-import io.gravitee.gateway.reactive.api.context.http.HttpExecutionContext;
+import io.gravitee.gateway.reactive.api.context.http.HttpBaseExecutionContext;
 import io.reactivex.rxjava3.core.Maybe;
 import org.jspecify.annotations.Nullable;
 
 public interface LlmRequestInspector {
-    KindSemantic kind(HttpExecutionContext context, JsonNode body);
+    KindSemantic kind(HttpBaseExecutionContext context, JsonNode body);
 
-    Maybe<String> prompt(@Nullable Buffer buffer, HttpExecutionContext context, PromptQuery promptQuery);
+    Maybe<String> prompt(HttpBaseExecutionContext context, PromptQuery promptQuery, @Nullable Buffer buffer);
 
     sealed interface PromptQuery {
         record LastUserPrompt() implements PromptQuery {}


### PR DESCRIPTION
https://gravitee.atlassian.net/browse/APIM-128

**Description**

A small description of what you did in that PR.

**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `6.0.0-mba-gma-128-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/gateway/gravitee-gateway-api/6.0.0-mba-gma-128-SNAPSHOT/gravitee-gateway-api-6.0.0-mba-gma-128-SNAPSHOT.zip)
  <!-- Version placeholder end -->
