### PR TITLE
fix: add Private Network Access header constants (APIM-13215)

### DIFF
--- a/src/main/java/io/gravitee/gateway/api/http/HttpHeaderNames.java
+++ b/src/main/java/io/gravitee/gateway/api/http/HttpHeaderNames.java
@@ -74,6 +74,14 @@ public interface HttpHeaderNames {
      */
     public static final String ACCESS_CONTROL_REQUEST_METHOD = "Access-Control-Request-Method";
     /**
+     * See {@link <a href="https://wicg.github.io/private-network-access/#headers">Private Network Access specification</a>}.
+     */
+    public static final String ACCESS_CONTROL_REQUEST_PRIVATE_NETWORK = "Access-Control-Request-Private-Network";
+    /**
+     * See {@link <a href="https://wicg.github.io/private-network-access/#headers">Private Network Access specification</a>}.
+     */
+    public static final String ACCESS_CONTROL_ALLOW_PRIVATE_NETWORK = "Access-Control-Allow-Private-Network";
+    /**
      * See {@link <a href="https://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.6">HTTP/1.1 documentation</a>}.
      */
     public static final String AGE = "Age";


### PR DESCRIPTION
Cherry-pick of b16b68d3 onto newly created `4.2.x` maintenance branch (forked from tag `4.2.0`) to enable backporting the APIM PNA CORS feature to APIM 4.10.x.

## Summary
- Adds `Access-Control-Request-Private-Network` and `Access-Control-Allow-Private-Network` constants to `HttpHeaderNames`.
- Required by gravitee-api-management PR #16670 (backport of #15957).

## Reference
- Jira: [APIM-13215](https://gravitee.atlassian.net/browse/APIM-13215)
- Original commit on master: gravitee-io/gravitee-gateway-api@b16b68d3
- Released as `5.1.1` on master line.

## Test plan
- [ ] CI green
- [ ] Resulting tag (`4.2.1`) consumed by APIM 4.10.x backport PR #16670

[APIM-13215]: https://gravitee.atlassian.net/browse/APIM-13215?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `4.2.1-wbabyte-cherry-pick-pna-4-2-x-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/gateway/gravitee-gateway-api/4.2.1-wbabyte-cherry-pick-pna-4-2-x-SNAPSHOT/gravitee-gateway-api-4.2.1-wbabyte-cherry-pick-pna-4-2-x-SNAPSHOT.zip)
  <!-- Version placeholder end -->
