### PR TITLE
fix: fix javadoc

### DIFF
--- a/src/main/java/io/gravitee/gateway/reactive/api/context/llm/LlmRequestInspector.java
+++ b/src/main/java/io/gravitee/gateway/reactive/api/context/llm/LlmRequestInspector.java
@@ -33,17 +33,17 @@ public interface LlmRequestInspector {
         record PendingUserPrompt() implements PromptQuery {}
 
         /**
-         * All messages of historic produced by user.
+         * All user prompts from history.
          */
         record AllUserPrompts() implements PromptQuery {}
 
         /**
-         * All prompt of historic (user, agent and tool)
+         * All prompts from history (user, agent, and tool).
          */
         record AllPrompts() implements PromptQuery {}
 
         /**
-         * Prompt defined by an Expression Langage
+         * Prompt defined by an Expression Language.
          */
         record CustomPrompt(String expressionLanguage) implements PromptQuery {}
     }


### PR DESCRIPTION
some fixes

(and my previous PR don’t produce a new version...)
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `6.0.0-mba-gma-128-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/gateway/gravitee-gateway-api/6.0.0-mba-gma-128-SNAPSHOT/gravitee-gateway-api-6.0.0-mba-gma-128-SNAPSHOT.zip)
  <!-- Version placeholder end -->
