### PR TITLE
feat(edge): add EDGE to ApiType enum

### DIFF
--- a/src/main/java/io/gravitee/gateway/reactive/api/ApiType.java
+++ b/src/main/java/io/gravitee/gateway/reactive/api/ApiType.java
@@ -28,25 +28,21 @@ import lombok.RequiredArgsConstructor;
 @Getter
 public enum ApiType {
     A2A_PROXY("a2a-proxy"),
+    EDGE("edge"),
     LLM_PROXY("llm-proxy"),
     MCP_PROXY("mcp-proxy"),
     PROXY("proxy"),
     MESSAGE("message"),
     NATIVE("native");
 
-    private static final Map<String, ApiType> LABELS_MAP = Map.of(
-        A2A_PROXY.label,
-        A2A_PROXY,
-        LLM_PROXY.label,
-        LLM_PROXY,
-        MCP_PROXY.label,
-        MCP_PROXY,
-        PROXY.label,
-        PROXY,
-        MESSAGE.label,
-        MESSAGE,
-        NATIVE.label,
-        NATIVE
+    private static final Map<String, ApiType> LABELS_MAP = Map.ofEntries(
+        Map.entry(A2A_PROXY.label, A2A_PROXY),
+        Map.entry(EDGE.label, EDGE),
+        Map.entry(LLM_PROXY.label, LLM_PROXY),
+        Map.entry(MCP_PROXY.label, MCP_PROXY),
+        Map.entry(PROXY.label, PROXY),
+        Map.entry(MESSAGE.label, MESSAGE),
+        Map.entry(NATIVE.label, NATIVE)
     );
 
     @JsonValue


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/GMA-334

**Description**

Add `EDGE("edge")` to the `ApiType` enum to support the new Edge reactor type.

Also migrates `LABELS_MAP` from `Map.of()` to `Map.ofEntries()` to accommodate the growing number of API types (Map.of is limited to 10 entries).
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `6.0.0-gma-334-edge-api-type-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/gateway/gravitee-gateway-api/6.0.0-gma-334-edge-api-type-SNAPSHOT/gravitee-gateway-api-6.0.0-gma-334-edge-api-type-SNAPSHOT.zip)
  <!-- Version placeholder end -->
