### PR TITLE
fix(tracing): record an exception event once per request

### DIFF
--- a/src/main/java/io/gravitee/gateway/reactive/api/tracing/Tracer.java
+++ b/src/main/java/io/gravitee/gateway/reactive/api/tracing/Tracer.java
@@ -17,6 +17,9 @@ package io.gravitee.gateway.reactive.api.tracing;
 
 import io.gravitee.node.api.opentelemetry.Span;
 import io.vertx.core.Context;
+import java.util.Collections;
+import java.util.IdentityHashMap;
+import java.util.Set;
 import java.util.function.BiConsumer;
 import lombok.RequiredArgsConstructor;
 
@@ -29,6 +32,9 @@ public class Tracer {
 
     private final Context vertxContext;
     private final io.gravitee.node.api.opentelemetry.Tracer delegate;
+
+    /** Throwable instances already recorded as an exception event, tracked by identity. */
+    private final Set<Throwable> recordedThrowables = Collections.synchronizedSet(Collections.newSetFromMap(new IdentityHashMap<>()));
 
     public <R> Span startRootSpanFrom(final R request) {
         return delegate.startRootSpanFrom(vertxContext, request);
@@ -46,12 +52,26 @@ public class Tracer {
         delegate.end(vertxContext, span);
     }
 
+    /**
+     * Ends the span on error. Records the exception event only the first time a given throwable
+     * instance is seen by this tracer; any later span fed the same instance is ended with a
+     * status-only error ({@link #endOnError(Span, String)}) so the failure stays visible without
+     * duplicating the event.
+     */
     public void endOnError(final Span span, final Throwable throwable) {
-        delegate.endOnError(vertxContext, span, throwable);
+        if (vertxContext == null || throwable == null || recordedThrowables.add(throwable)) {
+            delegate.endOnError(vertxContext, span, throwable);
+        } else {
+            delegate.endOnError(vertxContext, span, messageOf(throwable));
+        }
     }
 
     public void endOnError(final Span span, final String message) {
         delegate.endOnError(vertxContext, span, message);
+    }
+
+    private static String messageOf(final Throwable throwable) {
+        return throwable.getMessage() != null ? throwable.getMessage() : throwable.getClass().getName();
     }
 
     public <R> void endWithResponse(final Span span, final R response) {

--- a/src/test/java/io/gravitee/gateway/reactive/api/tracing/TracerTest.java
+++ b/src/test/java/io/gravitee/gateway/reactive/api/tracing/TracerTest.java
@@ -1,0 +1,139 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gateway.reactive.api.tracing;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+
+import io.gravitee.node.api.opentelemetry.Span;
+import io.vertx.core.Context;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class TracerTest {
+
+    private Context vertxContext;
+    private io.gravitee.node.api.opentelemetry.Tracer delegate;
+    private Span span;
+
+    @BeforeEach
+    void setUp() {
+        // The dedup only branches on vertxContext being null vs non-null — a bare mock is enough.
+        vertxContext = mock(Context.class);
+        delegate = mock(io.gravitee.node.api.opentelemetry.Tracer.class);
+        span = mock(Span.class);
+    }
+
+    @Test
+    void should_record_exception_event_on_first_sighting() {
+        Tracer tracer = new Tracer(vertxContext, delegate);
+        RuntimeException ex = new RuntimeException("boom");
+
+        tracer.endOnError(span, ex);
+
+        verify(delegate).endOnError(vertxContext, span, ex);
+        verifyNoMoreInteractions(delegate);
+    }
+
+    @Test
+    void should_downgrade_to_status_only_when_same_instance_seen_again() {
+        // One Tracer per request, shared across layers via ctx.getTracer(). The deeper span records
+        // the event; an outer span on the same request + same exception instance gets status-only.
+        Tracer tracer = new Tracer(vertxContext, delegate);
+        RuntimeException ex = new RuntimeException("boom");
+        Span outerSpan = mock(Span.class);
+
+        tracer.endOnError(span, ex);
+        tracer.endOnError(outerSpan, ex);
+
+        verify(delegate).endOnError(vertxContext, span, ex);
+        verify(delegate).endOnError(vertxContext, outerSpan, "boom");
+        verifyNoMoreInteractions(delegate);
+    }
+
+    @Test
+    void should_record_event_for_each_distinct_instance() {
+        Tracer tracer = new Tracer(vertxContext, delegate);
+        RuntimeException first = new RuntimeException("a");
+        // A layer that wraps + rethrows produces a new instance — its own stack trace is worth its own event.
+        IllegalStateException wrapped = new IllegalStateException("b", first);
+        Span wrapperSpan = mock(Span.class);
+
+        tracer.endOnError(span, first);
+        tracer.endOnError(wrapperSpan, wrapped);
+
+        verify(delegate).endOnError(vertxContext, span, first);
+        verify(delegate).endOnError(vertxContext, wrapperSpan, wrapped);
+        verifyNoMoreInteractions(delegate);
+    }
+
+    @Test
+    void should_fall_back_to_class_name_when_message_is_null() {
+        Tracer tracer = new Tracer(vertxContext, delegate);
+        RuntimeException ex = new RuntimeException(); // null message
+        Span outerSpan = mock(Span.class);
+
+        tracer.endOnError(span, ex);
+        tracer.endOnError(outerSpan, ex);
+
+        verify(delegate).endOnError(vertxContext, span, ex);
+        verify(delegate).endOnError(vertxContext, outerSpan, RuntimeException.class.getName());
+        verifyNoMoreInteractions(delegate);
+    }
+
+    @Test
+    void should_not_share_dedup_state_across_distinct_tracer_instances() {
+        // Two Tracer instances model two requests — each has its own dedup set, so the same exception
+        // instance is recorded independently by each.
+        RuntimeException ex = new RuntimeException("boom");
+
+        new Tracer(vertxContext, delegate).endOnError(span, ex);
+        new Tracer(vertxContext, delegate).endOnError(span, ex);
+
+        verify(delegate, org.mockito.Mockito.times(2)).endOnError(vertxContext, span, ex);
+        verifyNoMoreInteractions(delegate);
+    }
+
+    @Test
+    void should_not_dedup_when_context_is_null() {
+        // Null context = the shared no-op Tracer singleton (tracing disabled). It has no request scope,
+        // so dedup is skipped and every call records — never accumulating throwables on the singleton.
+        Tracer noopLike = new Tracer(null, delegate);
+        RuntimeException ex = new RuntimeException("boom");
+        Span outerSpan = mock(Span.class);
+
+        noopLike.endOnError(span, ex);
+        noopLike.endOnError(outerSpan, ex);
+
+        verify(delegate).endOnError(null, span, ex);
+        verify(delegate).endOnError(null, outerSpan, ex);
+        verifyNoMoreInteractions(delegate);
+    }
+
+    @Test
+    void should_pass_null_throwable_through_unchanged() {
+        Tracer tracer = new Tracer(vertxContext, delegate);
+
+        tracer.endOnError(span, (Throwable) null);
+
+        verify(delegate).endOnError(vertxContext, span, (Throwable) null);
+        verifyNoMoreInteractions(delegate);
+    }
+}


### PR DESCRIPTION
## Problem
The same exception propagates through every nested tracing layer (policy span, policy-chain span, execution-phase span, endpoint connector span, …) and each layer calls `endOnError(span, throwable)` on its own span — so one exception is recorded as an `exception` event on N spans.

## Fix
`Tracer` now records the exception event only the first time it sees a given throwable instance; any later span fed the same instance is ended status-only (`endOnError(span, message)`) so the failure stays visible up the parent chain without duplicating the stack-trace event.

- Dedup is per-`Tracer` instance — one is created per request and shared across all layers via `ctx.getTracer()`, so it's request-scoped.
- Identity-based (`IdentityHashMap`), so a layer that wraps + rethrows a new instance still gets its own event.
- Skipped when the context is null (the shared no-op tracer), avoiding any cross-request accumulation.

## Test plan
- [x] `TracerTest` (7 cases): first-sighting records, same-instance downgrades to status-only, distinct instances each record, null-message falls back to class name, distinct tracers don't share, null context never dedups, null throwable passes through.
- [x] Verified end-to-end on a local gateway — a failing HTTP callout now produces a single `exception` event on the deepest span, with all ancestors ERROR status-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `6.0.0-proto-tracer-record-exception-once-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/gateway/gravitee-gateway-api/6.0.0-proto-tracer-record-exception-once-SNAPSHOT/gravitee-gateway-api-6.0.0-proto-tracer-record-exception-once-SNAPSHOT.zip)
  <!-- Version placeholder end -->
