### PR TITLE
feat: add AUTHZ to ApiType enum

### DIFF
--- a/src/main/java/io/gravitee/gateway/reactive/api/ApiType.java
+++ b/src/main/java/io/gravitee/gateway/reactive/api/ApiType.java
@@ -28,6 +28,7 @@ import lombok.RequiredArgsConstructor;
 @Getter
 public enum ApiType {
     A2A_PROXY("a2a-proxy"),
+    AUTHZ("authz"),
     EDGE("edge"),
     LLM_PROXY("llm-proxy"),
     MCP_PROXY("mcp-proxy"),
@@ -37,6 +38,7 @@ public enum ApiType {
 
     private static final Map<String, ApiType> LABELS_MAP = Map.ofEntries(
         Map.entry(A2A_PROXY.label, A2A_PROXY),
+        Map.entry(AUTHZ.label, AUTHZ),
         Map.entry(EDGE.label, EDGE),
         Map.entry(LLM_PROXY.label, LLM_PROXY),
         Map.entry(MCP_PROXY.label, MCP_PROXY),


### PR DESCRIPTION
## What
Adds a new `AUTHZ("authz")` constant to `io.gravitee.gateway.reactive.api.ApiType` (and its label lookup map).

