### PR TITLE
feat: add entity resolver to execution context

### DIFF
--- a/src/main/java/io/gravitee/gateway/reactive/api/context/base/BaseExecutionContext.java
+++ b/src/main/java/io/gravitee/gateway/reactive/api/context/base/BaseExecutionContext.java
@@ -17,6 +17,7 @@ package io.gravitee.gateway.reactive.api.context.base;
 
 import io.gravitee.el.TemplateEngine;
 import io.gravitee.gateway.reactive.api.ExecutionWarn;
+import io.gravitee.gateway.reactive.api.context.EntityResolver;
 import io.gravitee.gateway.reactive.api.context.TlsSession;
 import io.gravitee.gateway.reactive.api.tracing.Tracer;
 import java.util.List;
@@ -181,6 +182,15 @@ public interface BaseExecutionContext {
      * @return the {@link Tracer} contextualized.
      */
     Tracer getTracer();
+
+    /**
+     * Get the {@link EntityResolver} that maps protocol-level resource names to catalog entity IDs.
+     *
+     * @return the {@link EntityResolver} for this execution context.
+     */
+    default EntityResolver entityResolver() {
+        return null;
+    }
 
     long timestamp();
 

--- a/src/test/java/io/gravitee/gateway/reactive/api/logging/AbstractBaseExecutionContextAwareLoggerTest.java
+++ b/src/test/java/io/gravitee/gateway/reactive/api/logging/AbstractBaseExecutionContextAwareLoggerTest.java
@@ -17,9 +17,9 @@ package io.gravitee.gateway.reactive.api.logging;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
 import io.gravitee.gateway.reactive.api.ExecutionWarn;
+import io.gravitee.gateway.reactive.api.context.EntityResolver;
 import io.gravitee.gateway.reactive.api.context.TlsSession;
 import io.gravitee.gateway.reactive.api.context.base.BaseExecutionContext;
 import io.gravitee.gateway.reactive.api.tracing.Tracer;
@@ -167,6 +167,11 @@ class AbstractBaseExecutionContextAwareLoggerTest {
 
         @Override
         public Tracer getTracer() {
+            return null;
+        }
+
+        @Override
+        public EntityResolver entityResolver() {
             return null;
         }
 


### PR DESCRIPTION

<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `6.3.0-gma-735-ctx-entity-resolver-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/gateway/gravitee-gateway-api/6.3.0-gma-735-ctx-entity-resolver-SNAPSHOT/gravitee-gateway-api-6.3.0-gma-735-ctx-entity-resolver-SNAPSHOT.zip)
  <!-- Version placeholder end -->
