### PR TITLE
feat: add WarmablePolicy interface for deploy-time policy warmup

### DIFF
--- a/src/main/java/io/gravitee/gateway/reactive/api/policy/http/WarmablePolicy.java
+++ b/src/main/java/io/gravitee/gateway/reactive/api/policy/http/WarmablePolicy.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gateway.reactive.api.policy.http;
+
+import io.gravitee.gateway.reactive.api.context.DeploymentContext;
+import io.reactivex.rxjava3.core.Completable;
+
+/**
+ * Optional interface for policies that need to pre-load external resources during API deployment.
+ *
+ * <p>Policies implementing this interface receive a warmup callback while the API reactor starts,
+ * after resources have been initialized. This runs on the deployment thread, so blocking I/O
+ * (HTTP calls, schema compilation) is permitted.</p>
+ *
+ * <p>If {@code warmup()} fails, the API deployment fails with a
+ * {@code io.gravitee.gateway.policy.PolicyWarmupException} (fail-fast).</p>
+ *
+ * @author GraviteeSource Team
+ */
+public interface WarmablePolicy {
+    /**
+     * Called during API deployment to pre-load resources.
+     *
+     * @param deploymentContext provides access to the {@code ResourceManager} and {@code TemplateEngine}
+     * @return a {@code Completable} that completes when warmup succeeds, or errors to fail deployment
+     */
+    Completable warmup(DeploymentContext deploymentContext);
+}


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/APIM-14959

**Description**

The APIM Gateway needs infrastructure so that policies can pre-load external resources at API deployment time — before the first request arrives. This is the foundation for registry-backed XML validation: the XSD schema must be fetched from a schema-registry resource and compiled when the API is deployed, so that:

The first request doesn't pay a cold-start registry fetch + compile latency
A bad/misconfigured schema fails the deployment fast, instead of every request failing at runtime
What this adds
A single new SPI interface in the gateway-api policy package:

public interface WarmablePolicy {
    Completable warmup(DeploymentContext deploymentContext);
}
Design notes:

Optional by design — only policies that implement WarmablePolicy get warmed up; existing policies are unaffected.
Blocking-safe — warmup runs on the deployment thread, so implementations may perform blocking I/O (HTTP calls, schema compilation).
Fail-fast contract — if warmup() errors, the deployment fails via PolicyWarmupException (handled in the consuming apim change), so the API never starts with a broken configuration.
Lives in io.gravitee.gateway.reactive.api.policy.http alongside HttpPolicy / HttpSecurityPolicy, matching the existing SPI layout.
Dependencies / companion changes
This is a prerequisite — it must be released before the consuming change in gravitee-api-management:

gravitee-api-management PR: feat(gateway): Adds infrastructure for deploy-time policy warmup (uses WarmablePolicy, DeploymentContext, and adds PolicyWarmupException, HttpPolicyFactory.warmupIfNeeded(), DefaultApiReactor.warmupPolicies(), FlowChain.warmupPolicies())
Once this PR is merged and released (as 6.3.1), the apim PR bumps gravitee-gateway-api.version from 6.3.0 → 6.3.1.
