### PR TITLE
feat(tracing): defer root-span attributes via the reactive Tracer

### DIFF
--- a/src/main/java/io/gravitee/gateway/reactive/api/tracing/Tracer.java
+++ b/src/main/java/io/gravitee/gateway/reactive/api/tracing/Tracer.java
@@ -19,7 +19,9 @@ import io.gravitee.node.api.opentelemetry.Span;
 import io.vertx.core.Context;
 import java.util.Collections;
 import java.util.IdentityHashMap;
+import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.BiConsumer;
 import lombok.RequiredArgsConstructor;
 
@@ -36,6 +38,14 @@ public class Tracer {
     /** Throwable instances already recorded as an exception event, tracked by identity. */
     private final Set<Throwable> recordedThrowables = Collections.synchronizedSet(Collections.newSetFromMap(new IdentityHashMap<>()));
 
+    /**
+     * Attributes deferred by request-scoped code (reactors, entrypoints, policies) to be stamped on the
+     * root span when it ends. Lets any caller enrich the root span through {@code ctx.getTracer()} without
+     * holding a reference to the span or knowing when it closes. Concurrent so a deferral from a thread other
+     * than the one closing the span (e.g. an off-context tool connector) stays visible at drain time.
+     */
+    private final Map<String, Object> deferredRootSpanAttributes = new ConcurrentHashMap<>();
+
     public <R> Span startRootSpanFrom(final R request) {
         return delegate.startRootSpanFrom(vertxContext, request);
     }
@@ -48,7 +58,27 @@ public class Tracer {
         return delegate.startSpanWithParentFrom(vertxContext, parentSpan, request);
     }
 
+    /**
+     * Defers a custom attribute to be stamped on the root span when it ends. Any request-scoped code with
+     * access to this {@link Tracer} (via {@code ctx.getTracer()}) can enrich the root span without holding a
+     * reference to it; the attribute is applied automatically at root-span close. No-op when {@code key} or
+     * {@code value} is {@code null}.
+     */
+    public void deferRootSpanAttribute(final String key, final Object value) {
+        if (key != null && value != null) {
+            deferredRootSpanAttributes.put(key, value);
+        }
+    }
+
+    /** Stamps the deferred attributes onto the span, but only when it is the root span. */
+    private void applyDeferredRootAttributes(final Span span) {
+        if (span != null && span.isRoot() && !deferredRootSpanAttributes.isEmpty()) {
+            deferredRootSpanAttributes.forEach(span::withAttribute);
+        }
+    }
+
     public void end(final Span span) {
+        applyDeferredRootAttributes(span);
         delegate.end(vertxContext, span);
     }
 
@@ -59,6 +89,7 @@ public class Tracer {
      * duplicating the event.
      */
     public void endOnError(final Span span, final Throwable throwable) {
+        applyDeferredRootAttributes(span);
         if (vertxContext == null || throwable == null || recordedThrowables.add(throwable)) {
             delegate.endOnError(vertxContext, span, throwable);
         } else {
@@ -67,6 +98,7 @@ public class Tracer {
     }
 
     public void endOnError(final Span span, final String message) {
+        applyDeferredRootAttributes(span);
         delegate.endOnError(vertxContext, span, message);
     }
 
@@ -75,14 +107,17 @@ public class Tracer {
     }
 
     public <R> void endWithResponse(final Span span, final R response) {
+        applyDeferredRootAttributes(span);
         delegate.endWithResponse(vertxContext, span, response);
     }
 
     public <R> void endWithResponseAndError(final Span span, final R response, final Throwable throwable) {
+        applyDeferredRootAttributes(span);
         delegate.endWithResponseAndError(vertxContext, span, response, throwable);
     }
 
     public <R> void endWithResponseAndError(final Span span, final R response, final String message) {
+        applyDeferredRootAttributes(span);
         delegate.endWithResponseAndError(vertxContext, span, response, message);
     }
 

--- a/src/test/java/io/gravitee/gateway/reactive/api/tracing/TracerTest.java
+++ b/src/test/java/io/gravitee/gateway/reactive/api/tracing/TracerTest.java
@@ -15,9 +15,13 @@
  */
 package io.gravitee.gateway.reactive.api.tracing;
 
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
 
 import io.gravitee.node.api.opentelemetry.Span;
 import io.vertx.core.Context;
@@ -135,5 +139,43 @@ class TracerTest {
 
         verify(delegate).endOnError(vertxContext, span, (Throwable) null);
         verifyNoMoreInteractions(delegate);
+    }
+
+    @Test
+    void should_stamp_deferred_attributes_on_root_span_when_it_ends() {
+        Tracer tracer = new Tracer(vertxContext, delegate);
+        when(span.isRoot()).thenReturn(true);
+
+        tracer.deferRootSpanAttribute("gravitee.entrypoint.id", "web-ai");
+        tracer.deferRootSpanAttribute("gravitee.conversation.id", "conv-1");
+        tracer.endWithResponseAndError(span, "response", (Throwable) null);
+
+        verify(span).withAttribute("gravitee.entrypoint.id", "web-ai");
+        verify(span).withAttribute("gravitee.conversation.id", "conv-1");
+        verify(delegate).endWithResponseAndError(vertxContext, span, "response", (Throwable) null);
+    }
+
+    @Test
+    void should_not_stamp_deferred_attributes_on_a_non_root_span() {
+        Tracer tracer = new Tracer(vertxContext, delegate);
+        // span.isRoot() defaults to false — a child (phase/hook) span must not receive root attributes.
+
+        tracer.deferRootSpanAttribute("gravitee.entrypoint.id", "web-ai");
+        tracer.end(span);
+
+        verify(span, never()).withAttribute(anyString(), any());
+        verify(delegate).end(vertxContext, span);
+    }
+
+    @Test
+    void should_ignore_null_key_or_value_when_deferring() {
+        Tracer tracer = new Tracer(vertxContext, delegate);
+        when(span.isRoot()).thenReturn(true);
+
+        tracer.deferRootSpanAttribute(null, "value");
+        tracer.deferRootSpanAttribute("key", null);
+        tracer.endWithResponse(span, "response");
+
+        verify(span, never()).withAttribute(anyString(), any());
     }
 }


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/APIM-15014

**Description**

Adds `Tracer#deferRootSpanAttribute(String, Object)` so request-scoped code (reactors, entrypoints, policies) can enrich the root span through `ctx.getTracer()` without holding a reference to it or knowing when it closes.

- Deferred attributes are stamped at root-span close by every `end*` overload, and only when `span.isRoot()`.
- A `null` key or value is a no-op.
- Backed by a `ConcurrentHashMap` on the per-request `Tracer`, so a deferral made from a thread other than the one closing the span stays visible at drain time.

**Additional context**

The first consumer is APIM: `SubscriptionProcessor` defers `gravitee.application.id` and `gravitee.application.name` onto the root span, so traces can be filtered by consuming application. That APIM change depends on this being released.
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `6.4.0-feat-APIM-15014-defer-root-span-attributes-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/gateway/gravitee-gateway-api/6.4.0-feat-APIM-15014-defer-root-span-attributes-SNAPSHOT/gravitee-gateway-api-6.4.0-feat-APIM-15014-defer-root-span-attributes-SNAPSHOT.zip)
  <!-- Version placeholder end -->
